### PR TITLE
Implement server config

### DIFF
--- a/ArmaServerManager/ArmaServerManager.csproj
+++ b/ArmaServerManager/ArmaServerManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,6 +12,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="example_common.Arma3Profile">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="example_common.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="example_server.cfg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="example_basic.cfg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/ArmaServerManager/ArmaServerManager.csproj
+++ b/ArmaServerManager/ArmaServerManager.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/ArmaServerManager/Modset.cs
+++ b/ArmaServerManager/Modset.cs
@@ -1,6 +1,5 @@
 ﻿namespace ArmaServerManager {
-    public class Modset
-    {
+    public class Modset {
         private string _modsetName = "default";
 
         public string GetName() => _modsetName;

--- a/ArmaServerManager/Modset.cs
+++ b/ArmaServerManager/Modset.cs
@@ -1,0 +1,8 @@
+﻿namespace ArmaServerManager {
+    public class Modset
+    {
+        private string _modsetName = "default";
+
+        public string GetName() => _modsetName;
+    }
+}

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -47,7 +47,7 @@ namespace ArmaServerManager
 
     public class Settings {
         private static IConfigurationRoot _config;
-        private readonly string _executable = "arma3server.exe";
+        private readonly string _executable = "arma3server_x64.exe";
         private readonly string _serverPath;
 
         public Settings() {

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.Configuration;
@@ -94,11 +95,21 @@ namespace ArmaServerManager
             Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
             // Load config directory and create if it not exists
-            string _serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
-            _serverConfigDir = $"{_settings.GetServerPath()}\\{_serverConfigDirName}";
+            string serverPath = settings.GetServerPath();
+            string serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
+            _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
             if (!Directory.Exists(_serverConfigDir)) {
-                Console.WriteLine($"Config directory {_serverConfigDirName} does not exists, creating.");
+                Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
                 Directory.CreateDirectory(_serverConfigDir);
+            }
+            // Check if common server configs are in place
+            var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
+            foreach (var fileName in filesList) {
+                string filePath = $"{_serverConfigDir}\\{fileName}";
+                if (!File.Exists(filePath)) {
+                    Console.WriteLine($"{fileName} not found, copying.");
+                    File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
+                }
             }
             Console.WriteLine("ServerConfig loaded.");
         }

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -95,8 +95,8 @@ namespace ArmaServerManager
             Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
             // Load config directory and create if it not exists
-            string serverPath = settings.GetServerPath();
-            string serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
+            var serverPath = settings.GetServerPath();
+            var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
             _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
             if (!Directory.Exists(_serverConfigDir)) {
                 Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
@@ -105,11 +105,10 @@ namespace ArmaServerManager
             // Check if common server configs are in place
             var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
             foreach (var fileName in filesList) {
-                string filePath = $"{_serverConfigDir}\\{fileName}";
-                if (!File.Exists(filePath)) {
-                    Console.WriteLine($"{fileName} not found, copying.");
-                    File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
-                }
+                var filePath = $"{_serverConfigDir}\\{fileName}";
+                if (File.Exists(filePath)) continue;
+                Console.WriteLine($"{fileName} not found, copying.");
+                File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
             }
             Console.WriteLine("ServerConfig loaded.");
         }

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -7,12 +7,6 @@ using Microsoft.Win32;
 
 namespace ArmaServerManager
 {
-    public class Modset {
-        private string _modsetName = "default";
-
-        public string GetName() => _modsetName;
-    }
-
     public class Server {
         private Settings _settings;
         private Modset _modset;

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -47,47 +47,6 @@ namespace ArmaServerManager
         }
     }
 
-    public class Settings {
-        private static IConfigurationRoot _config;
-        private readonly string _executable = "arma3server_x64.exe";
-        private readonly string _serverPath;
-
-        public Settings() {
-            Console.WriteLine("Loading Manager Settings.");
-            // Load config
-            _config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("settings.json")
-                .AddEnvironmentVariables()
-                .Build();
-            // Load serverPath
-            try {
-                _serverPath = _config["serverPath"];
-            } catch (NullReferenceException) {
-                _serverPath = Registry.LocalMachine
-                    .OpenSubKey("SOFTWARE\\WOW6432Node\\bohemia interactive\\arma 3")
-                    ?.GetValue("main")
-                    .ToString();
-            }
-        }
-
-        public object GetSettingsValue(string key) {
-            try {
-                return _config[key];
-            } catch (NullReferenceException) {
-                return null;
-            }
-        }
-
-        public string GetServerPath() {
-            return _serverPath;
-        }
-
-        public string GetServerExePath() {
-            return _serverPath != null ? $"{_serverPath}\\{_executable}" : null;
-        }
-    }
-
     internal class Program
     {
         static void Main(string[] args) {

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -89,10 +89,8 @@ namespace ArmaServerManager
             return _serverPath;
         }
 
-        public string GetServerExePath()
-        {
-            if (_serverPath != null) return $"{_serverPath}\\{_executable}";
-            return null;
+        public string GetServerExePath() {
+            return _serverPath != null ? $"{_serverPath}\\{_executable}" : null;
         }
     }
 

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.Configuration;
@@ -8,9 +8,11 @@ namespace ArmaServerManager
 {
     public class Server {
         private Settings _settings;
+        private ServerConfig _armaConfig;
         private Process _serverProcess;
         public Server() {
             _settings = new Settings();
+            _armaConfig = new ServerConfig(_settings);
         }
 
         public bool IsServerRunning() {
@@ -60,10 +62,37 @@ namespace ArmaServerManager
             }
         }
 
+        public object GetSettingsValue(string key) {
+            try {
+                return _config[key];
+            } catch (NullReferenceException) {
+                return null;
+            }
+        }
+
+        public string GetServerPath() {
+            return _serverPath;
+        }
+
         public string GetServerExePath()
         {
             if (_serverPath != null) return $"{_serverPath}\\{_executable}";
             return null;
+        }
+    }
+
+    public class ServerConfig {
+        private readonly Settings _settings;
+        private string _serverConfigDir;
+        public ServerConfig(Settings settings) {
+            _settings = settings;
+            // Load config directory and create if it not exists
+            string _serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
+            _serverConfigDir = $"{_settings.GetServerPath()}\\{_serverConfigDirName}";
+            if (!Directory.Exists(_serverConfigDir)) {
+                Console.WriteLine($"Config directory {_serverConfigDirName} does not exists, creating.");
+                Directory.CreateDirectory(_serverConfigDir);
+            }
         }
     }
 

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -1,7 +1,5 @@
-namespace ArmaServerManager
-{
-    internal class Program
-    {
+namespace ArmaServerManager {
+    internal class Program {
         static void Main(string[] args) {
             var server = new Server();
             server.Start();

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -1,52 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Win32;
-
 namespace ArmaServerManager
 {
-    public class Server {
-        private Settings _settings;
-        private Modset _modset;
-        private ServerConfig _armaConfig;
-        private Process _serverProcess;
-        public Server() {
-            Console.WriteLine("Initializing Server");
-            _settings = new Settings();
-            _modset = new Modset();
-            _armaConfig = new ServerConfig(_settings, _modset);
-        }
-
-        public bool IsServerRunning() {
-            return _serverProcess != null ? true : false;
-        }
-
-        public bool Start() {
-            Console.WriteLine("Starting Arma 3 Server");
-            try {
-                _serverProcess = Process.Start(_settings.GetServerExePath());
-            } catch (NullReferenceException e) {
-                Console.WriteLine(e);
-                Console.WriteLine("Arma 3 Server could not be started. Path missing.");
-                return false;
-            }
-            return true;
-        }
-
-        public void WaitUntilStarted() {
-            Console.WriteLine($"Waiting for {_serverProcess} to finish startup.");
-            _serverProcess.WaitForInputIdle();
-        }
-
-        public void Shutdown() {
-            Console.WriteLine($"Shutting down the {_serverProcess}.");
-            _serverProcess.Kill();
-            _serverProcess = null;
-        }
-    }
-
     internal class Program
     {
         static void Main(string[] args) {

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -7,14 +7,22 @@ using Microsoft.Win32;
 
 namespace ArmaServerManager
 {
+    public class Modset {
+        private string _modsetName = "default";
+
+        public string GetName() => _modsetName;
+    }
+
     public class Server {
         private Settings _settings;
+        private Modset _modset;
         private ServerConfig _armaConfig;
         private Process _serverProcess;
         public Server() {
             Console.WriteLine("Initializing Server");
             _settings = new Settings();
-            _armaConfig = new ServerConfig(_settings);
+            _modset = new Modset();
+            _armaConfig = new ServerConfig(_settings, _modset);
         }
 
         public bool IsServerRunning() {
@@ -90,10 +98,13 @@ namespace ArmaServerManager
 
     public class ServerConfig {
         private readonly Settings _settings;
+        private readonly Modset _modset;
         private string _serverConfigDir;
         public ServerConfig(Settings settings) {
+        public ServerConfig(Settings settings, Modset modset) {
             Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
+            _modset = modset;
             // Load config directory and create if it not exists
             var serverPath = settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -94,58 +94,6 @@ namespace ArmaServerManager
         }
     }
 
-    public class ServerConfig {
-        private readonly Settings _settings;
-        private readonly Modset _modset;
-        private string _serverConfigDir;
-
-        /// <summary>
-        /// Class prepares server configuration for given modset
-        /// </summary>
-        /// <param name="settings">Server Settings Object</param>
-        /// <param name="modset">Modset object</param>
-        public ServerConfig(Settings settings, Modset modset) {
-            Console.WriteLine("Loading ServerConfig.");
-            _settings = settings;
-            _modset = modset;
-            // Load config directory and create if it not exists
-            PrepareModsetConfig();
-            
-            Console.WriteLine("ServerConfig loaded.");
-        }
-
-        /// <summary>
-        /// Prepares common serverConfig directory and files
-        /// </summary>
-        private string PrepareServerConfig() {
-            var serverPath = _settings.GetServerPath();
-            var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
-            _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
-            if (Directory.Exists(_serverConfigDir)) return _serverConfigDir;
-            Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
-            Directory.CreateDirectory(_serverConfigDir);
-            // Check if common server configs are in place
-            var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
-            foreach (var fileName in filesList)
-            {
-                var filePath = $"{_serverConfigDir}\\{fileName}";
-                if (File.Exists(filePath)) continue;
-                Console.WriteLine($"{fileName} not found, copying.");
-                File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
-            }
-            return _serverConfigDir;
-        }
-
-        /// <summary>
-        /// Prepares modset specific config directory and files.
-        /// </summary>
-        private void PrepareModsetConfig() {
-            // Get modset config directory based on serverConfig
-            var modsetConfigDir = PrepareServerConfig() + $"modsetConfigs\\{_modset.GetName()}";
-
-        }
-    }
-
     internal class Program
     {
         static void Main(string[] args) {

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -11,6 +11,7 @@ namespace ArmaServerManager
         private ServerConfig _armaConfig;
         private Process _serverProcess;
         public Server() {
+            Console.WriteLine("Initializing Server");
             _settings = new Settings();
             _armaConfig = new ServerConfig(_settings);
         }
@@ -20,20 +21,24 @@ namespace ArmaServerManager
         }
 
         public bool Start() {
+            Console.WriteLine("Starting Arma 3 Server");
             try {
                 _serverProcess = Process.Start(_settings.GetServerExePath());
             } catch (NullReferenceException e) {
                 Console.WriteLine(e);
+                Console.WriteLine("Arma 3 Server could not be started. Path missing.");
                 return false;
             }
             return true;
         }
 
         public void WaitUntilStarted() {
+            Console.WriteLine($"Waiting for {_serverProcess} to finish startup.");
             _serverProcess.WaitForInputIdle();
         }
 
         public void Shutdown() {
+            Console.WriteLine($"Shutting down the {_serverProcess}.");
             _serverProcess.Kill();
             _serverProcess = null;
         }
@@ -45,6 +50,7 @@ namespace ArmaServerManager
         private readonly string _serverPath;
 
         public Settings() {
+            Console.WriteLine("Loading Manager Settings.");
             // Load config
             _config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
@@ -85,6 +91,7 @@ namespace ArmaServerManager
         private readonly Settings _settings;
         private string _serverConfigDir;
         public ServerConfig(Settings settings) {
+            Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
             // Load config directory and create if it not exists
             string _serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
@@ -93,6 +100,7 @@ namespace ArmaServerManager
                 Console.WriteLine($"Config directory {_serverConfigDirName} does not exists, creating.");
                 Directory.CreateDirectory(_serverConfigDir);
             }
+            Console.WriteLine("ServerConfig loaded.");
         }
     }
 
@@ -100,7 +108,6 @@ namespace ArmaServerManager
     {
         static void Main(string[] args) {
             var server = new Server();
-            Console.WriteLine("Starting Arma 3 Server");
             server.Start();
             server.WaitUntilStarted();
             server.Shutdown();

--- a/ArmaServerManager/Program.cs
+++ b/ArmaServerManager/Program.cs
@@ -100,28 +100,51 @@ namespace ArmaServerManager
         private readonly Settings _settings;
         private readonly Modset _modset;
         private string _serverConfigDir;
-        public ServerConfig(Settings settings) {
+
+        /// <summary>
+        /// Class prepares server configuration for given modset
+        /// </summary>
+        /// <param name="settings">Server Settings Object</param>
+        /// <param name="modset">Modset object</param>
         public ServerConfig(Settings settings, Modset modset) {
             Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
             _modset = modset;
             // Load config directory and create if it not exists
-            var serverPath = settings.GetServerPath();
+            PrepareModsetConfig();
+            
+            Console.WriteLine("ServerConfig loaded.");
+        }
+
+        /// <summary>
+        /// Prepares common serverConfig directory and files
+        /// </summary>
+        private string PrepareServerConfig() {
+            var serverPath = _settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
             _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
-            if (!Directory.Exists(_serverConfigDir)) {
-                Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
-                Directory.CreateDirectory(_serverConfigDir);
-            }
+            if (Directory.Exists(_serverConfigDir)) return _serverConfigDir;
+            Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
+            Directory.CreateDirectory(_serverConfigDir);
             // Check if common server configs are in place
-            var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
-            foreach (var fileName in filesList) {
+            var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
+            foreach (var fileName in filesList)
+            {
                 var filePath = $"{_serverConfigDir}\\{fileName}";
                 if (File.Exists(filePath)) continue;
                 Console.WriteLine($"{fileName} not found, copying.");
                 File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
             }
-            Console.WriteLine("ServerConfig loaded.");
+            return _serverConfigDir;
+        }
+
+        /// <summary>
+        /// Prepares modset specific config directory and files.
+        /// </summary>
+        private void PrepareModsetConfig() {
+            // Get modset config directory based on serverConfig
+            var modsetConfigDir = PrepareServerConfig() + $"modsetConfigs\\{_modset.GetName()}";
+
         }
     }
 

--- a/ArmaServerManager/Properties/launchSettings.json
+++ b/ArmaServerManager/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "ArmaServerManager": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "hostNamePattern": "ArmaForces {0} edition"
+      }
+    }
+  }
+}

--- a/ArmaServerManager/Server.cs
+++ b/ArmaServerManager/Server.cs
@@ -13,6 +13,7 @@ namespace ArmaServerManager {
             _settings = new Settings();
             _modset = new Modset();
             _armaConfig = new ServerConfig(_settings, _modset.GetName());
+            _armaConfig.LoadConfig();
         }
 
         public bool IsServerRunning() {

--- a/ArmaServerManager/Server.cs
+++ b/ArmaServerManager/Server.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
+using Microsoft.Extensions.Configuration;
 
 namespace ArmaServerManager {
     public class Server {
@@ -10,7 +12,12 @@ namespace ArmaServerManager {
 
         public Server() {
             Console.WriteLine("Initializing Server");
-            _settings = new Settings();
+            var config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("settings.json")
+                .AddEnvironmentVariables()
+                .Build();
+            _settings = new Settings(config);
             _modset = new Modset();
             _armaConfig = new ServerConfig(_settings, _modset.GetName());
             _armaConfig.LoadConfig();

--- a/ArmaServerManager/Server.cs
+++ b/ArmaServerManager/Server.cs
@@ -12,7 +12,7 @@ namespace ArmaServerManager {
             Console.WriteLine("Initializing Server");
             _settings = new Settings();
             _modset = new Modset();
-            _armaConfig = new ServerConfig(_settings, _modset);
+            _armaConfig = new ServerConfig(_settings, _modset.GetName());
         }
 
         public bool IsServerRunning() {

--- a/ArmaServerManager/Server.cs
+++ b/ArmaServerManager/Server.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ArmaServerManager {
+    public class Server
+    {
+        private Settings _settings;
+        private Modset _modset;
+        private ServerConfig _armaConfig;
+        private Process _serverProcess;
+        public Server()
+        {
+            Console.WriteLine("Initializing Server");
+            _settings = new Settings();
+            _modset = new Modset();
+            _armaConfig = new ServerConfig(_settings, _modset);
+        }
+
+        public bool IsServerRunning()
+        {
+            return _serverProcess != null ? true : false;
+        }
+
+        public bool Start()
+        {
+            Console.WriteLine("Starting Arma 3 Server");
+            try
+            {
+                _serverProcess = Process.Start(_settings.GetServerExePath());
+            }
+            catch (NullReferenceException e)
+            {
+                Console.WriteLine(e);
+                Console.WriteLine("Arma 3 Server could not be started. Path missing.");
+                return false;
+            }
+            return true;
+        }
+
+        public void WaitUntilStarted()
+        {
+            Console.WriteLine($"Waiting for {_serverProcess} to finish startup.");
+            _serverProcess.WaitForInputIdle();
+        }
+
+        public void Shutdown()
+        {
+            Console.WriteLine($"Shutting down the {_serverProcess}.");
+            _serverProcess.Kill();
+            _serverProcess = null;
+        }
+    }
+
+}

--- a/ArmaServerManager/Server.cs
+++ b/ArmaServerManager/Server.cs
@@ -16,7 +16,7 @@ namespace ArmaServerManager {
         }
 
         public bool IsServerRunning() {
-            return _serverProcess != null ? true : false;
+            return _serverProcess != null;
         }
 
         public bool Start() {

--- a/ArmaServerManager/Server.cs
+++ b/ArmaServerManager/Server.cs
@@ -2,53 +2,45 @@
 using System.Diagnostics;
 
 namespace ArmaServerManager {
-    public class Server
-    {
+    public class Server {
         private Settings _settings;
         private Modset _modset;
         private ServerConfig _armaConfig;
         private Process _serverProcess;
-        public Server()
-        {
+
+        public Server() {
             Console.WriteLine("Initializing Server");
             _settings = new Settings();
             _modset = new Modset();
             _armaConfig = new ServerConfig(_settings, _modset);
         }
 
-        public bool IsServerRunning()
-        {
+        public bool IsServerRunning() {
             return _serverProcess != null ? true : false;
         }
 
-        public bool Start()
-        {
+        public bool Start() {
             Console.WriteLine("Starting Arma 3 Server");
-            try
-            {
+            try {
                 _serverProcess = Process.Start(_settings.GetServerExePath());
-            }
-            catch (NullReferenceException e)
-            {
+            } catch (NullReferenceException e) {
                 Console.WriteLine(e);
                 Console.WriteLine("Arma 3 Server could not be started. Path missing.");
                 return false;
             }
+
             return true;
         }
 
-        public void WaitUntilStarted()
-        {
+        public void WaitUntilStarted() {
             Console.WriteLine($"Waiting for {_serverProcess} to finish startup.");
             _serverProcess.WaitForInputIdle();
         }
 
-        public void Shutdown()
-        {
+        public void Shutdown() {
             Console.WriteLine($"Shutting down the {_serverProcess}.");
             _serverProcess.Kill();
             _serverProcess = null;
         }
     }
-
 }

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -29,9 +29,8 @@ namespace ArmaServerManager {
         public Result LoadConfig() {
             Console.WriteLine("Loading ServerConfig.");
             var configLoaded = GetOrCreateServerConfigDir()
-                .Tap(serverConfigDir => _serverConfigDir = serverConfigDir)
-                .Bind(serverConfigDir => GetOrCreateModsetConfigDir(_serverConfigDir, _modsetName))
-                .Bind(modsetConfigDir => PrepareModsetConfig(_serverConfigDir, modsetConfigDir, _modsetName))
+                .Bind(serverConfigDir => GetOrCreateModsetConfigDir(serverConfigDir, _modsetName))
+                .Bind(modsetConfigDir => PrepareModsetConfig(modsetConfigDir, _modsetName))
                 .Tap(() => Console.WriteLine("ServerConfig loaded."))
                 .OnFailure(e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
             return configLoaded;
@@ -96,8 +95,9 @@ namespace ArmaServerManager {
         /// <summary>
         /// Prepares modset cfg files for server to load.
         /// </summary>
-        private Result PrepareModsetConfig(string serverConfigDir, string modsetConfigDir, string modsetName) {
+        private Result PrepareModsetConfig(string modsetConfigDir, string modsetName) {
             // Apply modset config on top of default config
+            var serverConfigDir = Path.GetFullPath(Path.Join("..", ".."), modsetConfigDir);
             var modsetConfig = new ConfigurationBuilder()
                 .AddJsonFile(Path.Join(serverConfigDir, "common.json"))
                 .AddJsonFile(Path.Join(modsetConfigDir, "config.json"))

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -33,9 +33,10 @@ namespace ArmaServerManager {
             var serverPath = _settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
             _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
-            if (Directory.Exists(_serverConfigDir)) return _serverConfigDir;
-            Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
-            Directory.CreateDirectory(_serverConfigDir);
+            if (!Directory.Exists(_serverConfigDir)) {
+                Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
+                Directory.CreateDirectory(_serverConfigDir);
+            }
             // Check if common server configs are in place
             var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
             foreach (var fileName in filesList)

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Microsoft.Extensions.Configuration;
 using System.Linq;
@@ -35,12 +34,10 @@ namespace ArmaServerManager {
         public void PrepareCommonFiles() {
             _serverConfigDir = GetOrCreateServerConfigDir();
             _modsetConfigDir = GetOrCreateModsetConfigDir();
-            CreateServerConfigIfDontExists();
-            CreateModsetConfigIfDontExists();
         }
 
         /// <summary>
-        /// Prepares serverConfig directory.
+        /// Prepares serverConfig directory with files.
         /// </summary>
         /// <returns>path to serverConfig</returns>
         private string GetOrCreateServerConfigDir() {
@@ -50,6 +47,15 @@ namespace ArmaServerManager {
             if (!Directory.Exists(serverConfigDir)) {
                 Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
                 Directory.CreateDirectory(serverConfigDir);
+            }
+
+            // Prepare files
+            var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
+            foreach (var fileName in filesList) {
+                var destFileName = Path.Join(_serverConfigDir, fileName);
+                if (File.Exists(destFileName)) continue;
+                Console.WriteLine($"{fileName} not found, copying.");
+                File.Copy(Path.Join(Directory.GetCurrentDirectory(), $"example_{fileName}"), destFileName);
             }
 
             return serverConfigDir;
@@ -67,28 +73,8 @@ namespace ArmaServerManager {
             if (!Directory.Exists(modsetConfigDir)) {
                 Directory.CreateDirectory(modsetConfigDir);
             }
-            
-            return modsetConfigDir;
-        }
 
-        /// <summary>
-        /// Checks if default configuration files exists and copies them from example files if they don't exist.
-        /// </summary>
-        /// <param name="serverConfigDir"></param>
-        private void CreateServerConfigIfDontExists() {
-            var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
-            foreach (var fileName in filesList) {
-                var destFileName = Path.Join(_serverConfigDir, fileName);
-                if (File.Exists(destFileName)) continue;
-                Console.WriteLine($"{fileName} not found, copying.");
-                File.Copy(Path.Join(Directory.GetCurrentDirectory(), $"example_{fileName}"), destFileName);
-            }
-        }
-
-        /// <summary>
-        /// If modset config.json is not present, create one with hostNamePattern.
-        /// </summary>
-        private void CreateModsetConfigIfDontExists() {
+            // Prepare modset specific config.json if not exists
             if (!File.Exists(Path.Join(_modsetConfigDir, "config.json"))) {
                 // Set hostName according to pattern
                 var sampleServer = new Dictionary<string, string>();
@@ -103,6 +89,8 @@ namespace ArmaServerManager {
                     serializer.Serialize(file, sampleJSON);
                 }
             }
+
+            return modsetConfigDir;
         }
 
         /// <summary>

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -7,8 +7,7 @@ using Microsoft.Extensions.Configuration;
 using System.Linq;
 
 namespace ArmaServerManager {
-    public class ServerConfig
-    {
+    public class ServerConfig {
         private readonly Settings _settings;
         private readonly Modset _modset;
         private string _serverConfigDir;
@@ -20,8 +19,7 @@ namespace ArmaServerManager {
         /// </summary>
         /// <param name="settings">Server Settings Object</param>
         /// <param name="modset">Modset object</param>
-        public ServerConfig(Settings settings, Modset modset)
-        {
+        public ServerConfig(Settings settings, Modset modset) {
             Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
             _modset = modset;
@@ -35,8 +33,7 @@ namespace ArmaServerManager {
         /// <summary>
         /// Prepares common serverConfig directory and files
         /// </summary>
-        private void PrepareServerConfig()
-        {
+        private void PrepareServerConfig() {
             var serverPath = _settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
             _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
@@ -44,15 +41,16 @@ namespace ArmaServerManager {
                 Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
                 Directory.CreateDirectory(_serverConfigDir);
             }
+
             // Check if common server configs are in place
-            var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
-            foreach (var fileName in filesList)
-            {
+            var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
+            foreach (var fileName in filesList) {
                 var filePath = $"{_serverConfigDir}\\{fileName}";
                 if (File.Exists(filePath)) continue;
                 Console.WriteLine($"{fileName} not found, copying.");
                 File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
             }
+
             // Load common config from JSON
             _commonConfig = new ConfigurationBuilder()
                 .SetBasePath(_serverConfigDir)
@@ -63,8 +61,7 @@ namespace ArmaServerManager {
         /// <summary>
         /// Prepares modset specific config directory and files.
         /// </summary>
-        private void PrepareModsetConfig()
-        {
+        private void PrepareModsetConfig() {
             // Get modset config directory based on serverConfig
             var modsetConfigDir = _serverConfigDir + $"\\modsetConfigs\\{_modset.GetName()}";
 
@@ -72,10 +69,12 @@ namespace ArmaServerManager {
             if (!Directory.Exists(modsetConfigDir)) {
                 Directory.CreateDirectory(modsetConfigDir);
             }
+
             if (!File.Exists($"{modsetConfigDir}\\config.json")) {
                 // Set hostName according to pattern
                 var sampleServer = new Dictionary<string, string>();
-                sampleServer.Add("hostName", string.Format(Environment.GetEnvironmentVariable("hostNamePattern"), _modset.GetName()));
+                sampleServer.Add("hostName",
+                    string.Format(Environment.GetEnvironmentVariable("hostNamePattern"), _modset.GetName()));
                 var sampleJSON = new Dictionary<string, Dictionary<string, string>>();
                 sampleJSON.Add("server", sampleServer);
                 // Write to file
@@ -95,7 +94,8 @@ namespace ArmaServerManager {
             var configs = new List<string> {"server", "basic"};
             foreach (var config in configs) {
                 Console.WriteLine($"Loading {config}.cfg for {_modset.GetName()} modset.");
-                var cfgFile = FillCfg(File.ReadAllText($"{_serverConfigDir}\\{config}.cfg"), _modsetConfig.GetSection(config));
+                var cfgFile = FillCfg(File.ReadAllText($"{_serverConfigDir}\\{config}.cfg"),
+                    _modsetConfig.GetSection(config));
                 File.WriteAllText($"{modsetConfigDir}\\{config}.cfg", cfgFile);
                 Console.WriteLine($"{config}.cfg successfully exported to {modsetConfigDir}");
             }
@@ -117,6 +117,7 @@ namespace ArmaServerManager {
                     cfgFile = ReplaceValue(cfgFile, key, config[key]);
                 }
             }
+
             return cfgFile;
         }
 
@@ -129,6 +130,7 @@ namespace ArmaServerManager {
             if (key == "template") {
                 expression = $"\t\t{key}";
             }
+
             // Check if $key contains '[]' eg. 'admins[]' as then it's value should be an array
             if (Regex.IsMatch(key, @"[[\]]")) {
                 // Make some magic to replace [] in expression to \[\]
@@ -152,12 +154,13 @@ namespace ArmaServerManager {
                 quote = "\"";
             }
 
-            var replacement = Regex.IsMatch(key, @"[[\]]") ? $"\n{key} = {{{value}}};" : $"\n{key} = {quote}{value}{quote};";
+            var replacement = Regex.IsMatch(key, @"[[\]]")
+                ? $"\n{key} = {{{value}}};"
+                : $"\n{key} = {quote}{value}{quote};";
             config = Regex.Replace(config, expression, replacement);
             Console.WriteLine($"\"{match.ToString().Substring(1)}\" => \"{replacement.Substring(1)}\"");
 
             return config;
         }
     }
-
 }

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -90,6 +90,19 @@ namespace ArmaServerManager {
                 .AddInMemoryCollection(_commonConfig.AsEnumerable())
                 .AddJsonFile("config.json")
                 .Build();
+            var cfgFile = FillCfg(File.ReadAllText($"{_serverConfigDir}\\server.cfg"), _modsetConfig.GetSection("server"));
+            File.WriteAllText($"{modsetConfigDir}\\server.cfg", cfgFile);
+        }
+
+        /// <summary>
+        /// In given cfgFile string replaces values for keys present in given config. Returns filled string.
+        /// </summary>
+        private string FillCfg(string cfgFile, IConfigurationSection config) {
+            foreach (var section in config.GetChildren()) {
+                var key = section.Key;
+                var value = section.Value;
+            }
+            return cfgFile;
         }
     }
 

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -103,8 +103,9 @@ namespace ArmaServerManager {
             foreach (var section in config.GetChildren()) {
                 var key = section.Key;
                 var value = config.GetSection(key).GetChildren().ToList();
-                // If value is array, it needs changing to string
+                // Replace default value in cfg with value from loaded configs
                 if (value.Count != 0) {
+                    // If value is array, it needs changing to string
                     var stringValue = String.Join(", ", value.Select(p => p.Value.ToString()));
                     cfgFile = ReplaceValue(cfgFile, key, stringValue);
                 } else {
@@ -114,6 +115,9 @@ namespace ArmaServerManager {
             return cfgFile;
         }
 
+        /// <summary>
+        /// Performs replacement of a value for correspoinding key in given config file (as string)
+        /// </summary>
         private string ReplaceValue(string config, string key, string value) {
             // Build regex expression with new line before key to prevent mid-line replacements
             var expression = $"\n{key}";

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -9,7 +9,6 @@ using CSharpFunctionalExtensions;
 namespace ArmaServerManager {
     public class ServerConfig {
         private readonly ISettings _settings;
-        private string _serverConfigDir;
         private readonly string _modsetName;
 
         /// <summary>

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -10,6 +10,7 @@ namespace ArmaServerManager {
         private readonly Modset _modset;
         private string _serverConfigDir;
         private IConfigurationRoot _commonConfig;
+        private IConfigurationRoot _modsetConfig;
 
         /// <summary>
         /// Class prepares server configuration for given modset
@@ -62,8 +63,14 @@ namespace ArmaServerManager {
         private void PrepareModsetConfig()
         {
             // Get modset config directory based on serverConfig
-            var modsetConfigDir = PrepareServerConfig() + $"modsetConfigs\\{_modset.GetName()}";
+            var modsetConfigDir = _serverConfigDir + $"\\modsetConfigs\\{_modset.GetName()}";
 
+            // Load modset specific config from JSON
+            _modsetConfig = new ConfigurationBuilder()
+                .SetBasePath(modsetConfigDir)
+                .AddInMemoryCollection(_commonConfig.AsEnumerable())
+                .AddJsonFile("config.json")
+                .Build();
         }
     }
 

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -104,7 +104,7 @@ namespace ArmaServerManager {
         /// <summary>
         /// In given cfgFile string replaces values for keys present in given config. Returns filled string.
         /// </summary>
-        private string FillCfg(string cfgFile, IConfigurationSection config) {
+        public static string FillCfg(string cfgFile, IConfigurationSection config) {
             foreach (var section in config.GetChildren()) {
                 var key = section.Key;
                 var value = config.GetSection(key).GetChildren().ToList();
@@ -123,7 +123,7 @@ namespace ArmaServerManager {
         /// <summary>
         /// Performs replacement of a value for corresponding key in given config file (as string)
         /// </summary>
-        private string ReplaceValue(string config, string key, string value) {
+        public static string ReplaceValue(string config, string key, string value) {
             // Build regex expression with new line before key to prevent mid-line replacements
             var expression = $"\n{key}";
             if (key == "template") {

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -8,7 +8,7 @@ using CSharpFunctionalExtensions;
 
 namespace ArmaServerManager {
     public class ServerConfig {
-        private readonly Settings _settings;
+        private readonly ISettings _settings;
         private string _serverConfigDir;
         private readonly string _modsetName;
 
@@ -17,7 +17,7 @@ namespace ArmaServerManager {
         /// </summary>
         /// <param name="settings">Server Settings Object</param>
         /// <param name="modset">Modset object</param>
-        public ServerConfig(Settings settings, string modsetName) {
+        public ServerConfig(ISettings settings, string modsetName) {
             _settings = settings;
             _modsetName = modsetName;
         }
@@ -30,7 +30,7 @@ namespace ArmaServerManager {
             Console.WriteLine("Loading ServerConfig.");
             var configLoaded = GetOrCreateServerConfigDir()
                 .Tap(serverConfigDir => _serverConfigDir = serverConfigDir)
-                .Bind(serverConfigDir => GetOrCreateModsetConfigDir(serverConfigDir, _modsetName))
+                .Bind(serverConfigDir => GetOrCreateModsetConfigDir(_serverConfigDir, _modsetName))
                 .Bind(modsetConfigDir => PrepareModsetConfig(_serverConfigDir, modsetConfigDir, _modsetName))
                 .Tap(() => Console.WriteLine("ServerConfig loaded."))
                 .OnFailure(e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
@@ -53,7 +53,7 @@ namespace ArmaServerManager {
             // Prepare files
             var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
             foreach (var fileName in filesList) {
-                var destFileName = Path.Join(_serverConfigDir, fileName);
+                var destFileName = Path.Join(serverConfigDir, fileName);
                 if (File.Exists(destFileName)) continue;
                 Console.WriteLine($"{fileName} not found, copying.");
                 File.Copy(Path.Join(Directory.GetCurrentDirectory(), $"example_{fileName}"), destFileName);
@@ -79,8 +79,7 @@ namespace ArmaServerManager {
             if (!File.Exists(Path.Join(modsetConfigDir, "config.json"))) {
                 // Set hostName according to pattern
                 var sampleServer = new Dictionary<string, string>();
-                sampleServer.Add("hostName",
-                    string.Format(Environment.GetEnvironmentVariable("hostNamePattern"), modsetName));
+                sampleServer.Add("hostName", $"ArmaForces {modsetName} edition");
                 var sampleJSON = new Dictionary<string, Dictionary<string, string>>();
                 sampleJSON.Add("server", sampleServer);
                 // Write to file

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -22,10 +22,14 @@ namespace ArmaServerManager {
             _modsetName = modsetName;
         }
 
+        /// <summary>
+        /// Handles preparation of all config files.
+        /// </summary>
+        /// <returns></returns>
         public Result LoadConfig() {
             Console.WriteLine("Loading ServerConfig.");
             var configLoaded = GetOrCreateServerConfigDir()
-                .Tap(serverConfigDir => { _serverConfigDir = serverConfigDir; })
+                .Tap(serverConfigDir => _serverConfigDir = serverConfigDir)
                 .Bind(serverConfigDir => GetOrCreateModsetConfigDir(serverConfigDir, _modsetName))
                 .Bind(modsetConfigDir => PrepareModsetConfig(_serverConfigDir, modsetConfigDir, _modsetName))
                 .Tap(() => Console.WriteLine("ServerConfig loaded."))
@@ -47,7 +51,7 @@ namespace ArmaServerManager {
             }
 
             // Prepare files
-            var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
+            var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
             foreach (var fileName in filesList) {
                 var destFileName = Path.Join(_serverConfigDir, fileName);
                 if (File.Exists(destFileName)) continue;

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -92,8 +92,13 @@ namespace ArmaServerManager {
                 .AddInMemoryCollection(_commonConfig.AsEnumerable())
                 .AddJsonFile("config.json")
                 .Build();
-            var cfgFile = FillCfg(File.ReadAllText($"{_serverConfigDir}\\server.cfg"), _modsetConfig.GetSection("server"));
-            File.WriteAllText($"{modsetConfigDir}\\server.cfg", cfgFile);
+            var configs = new List<string> {"server", "basic"};
+            foreach (var config in configs) {
+                Console.WriteLine($"Loading {config}.cfg for {_modset.GetName()} modset.");
+                var cfgFile = FillCfg(File.ReadAllText($"{_serverConfigDir}\\{config}.cfg"), _modsetConfig.GetSection(config));
+                File.WriteAllText($"{modsetConfigDir}\\{config}.cfg", cfgFile);
+                Console.WriteLine($"{config}.cfg successfully exported to {modsetConfigDir}");
+            }
         }
 
         /// <summary>

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -10,6 +10,7 @@ namespace ArmaServerManager {
     public class ServerConfig {
         private readonly Settings _settings;
         private string _serverConfigDir;
+        private readonly string _modsetName;
 
         /// <summary>
         /// Class prepares server configuration for given modset
@@ -17,13 +18,19 @@ namespace ArmaServerManager {
         /// <param name="settings">Server Settings Object</param>
         /// <param name="modset">Modset object</param>
         public ServerConfig(Settings settings, string modsetName) {
-            Console.WriteLine("Loading ServerConfig.");
             _settings = settings;
-            GetOrCreateServerConfigDir()
+            _modsetName = modsetName;
+        }
+
+        public Result LoadConfig() {
+            Console.WriteLine("Loading ServerConfig.");
+            var configLoaded = GetOrCreateServerConfigDir()
                 .Tap(serverConfigDir => { _serverConfigDir = serverConfigDir; })
-                .Bind(serverConfigDir => GetOrCreateModsetConfigDir(serverConfigDir, modsetName))
-                .Bind(modsetConfigDir=> PrepareModsetConfig(_serverConfigDir, modsetConfigDir, modsetName))
-                .Match(() => Console.WriteLine("ServerConfig loaded."), e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
+                .Bind(serverConfigDir => GetOrCreateModsetConfigDir(serverConfigDir, _modsetName))
+                .Bind(modsetConfigDir => PrepareModsetConfig(_serverConfigDir, modsetConfigDir, _modsetName))
+                .Tap(() => Console.WriteLine("ServerConfig loaded."))
+                .OnFailure(e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
+            return configLoaded;
         }
 
         /// <summary>

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -111,7 +111,7 @@ namespace ArmaServerManager {
         private void PrepareModsetConfig() {
             // Apply modset config on top of default config
             var modsetConfig = new ConfigurationBuilder()
-                .AddJsonFile(Path.Join(_serverConfigDir, "config.json"))
+                .AddJsonFile(Path.Join(_serverConfigDir, "common.json"))
                 .AddJsonFile(Path.Join(_modsetConfigDir, "config.json"))
                 .Build();
 

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -30,20 +30,17 @@ namespace ArmaServerManager {
             Console.WriteLine("ServerConfig loaded.");
         }
 
-        public void PrepareCommonFiles()
-        {
+        public void PrepareCommonFiles() {
             var serverConfigDir = GetOrCreateServerConfigDir();
             PrepareCommonConfig();
             CreateServerFilesIfDontExists(serverConfigDir);
         }
 
-        private string GetOrCreateServerConfigDir()
-        {
+        private string GetOrCreateServerConfigDir() {
             var serverPath = _settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
             var serverConfigDir = Path.Join(serverPath, serverConfigDirName);
-            if (!Directory.Exists(_serverConfigDir))
-            {
+            if (!Directory.Exists(_serverConfigDir)) {
                 Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
                 Directory.CreateDirectory(_serverConfigDir);
             }
@@ -51,18 +48,16 @@ namespace ArmaServerManager {
             return serverConfigDir;
         }
 
-        private void PrepareCommonConfig()
-        {
+        private void PrepareCommonConfig() {
             _commonConfig = new ConfigurationBuilder()
                 .SetBasePath(_serverConfigDir)
                 .AddJsonFile("common.json")
                 .Build();
         }
 
-        private void CreateServerFilesIfDontExists(string path)
-        {
+        private void CreateServerFilesIfDontExists(string path) {
             var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
-            foreach (var fileName in filesList)
+            foreach (var fileName in filesList) {
                 var destFileName = Path.Join(path, fileName);
                 if (File.Exists(destFileName)) continue;
                 Console.WriteLine($"{fileName} not found, copying.");
@@ -107,14 +102,12 @@ namespace ArmaServerManager {
             }
         }
 
-        private string PrepareModsetConfigDir()
-        {
+        private string PrepareModsetConfigDir() {
             // Get modset config directory based on serverConfig
             var modsetConfigDir = Path.Join(_serverConfigDir, "modsetConfigs", _modset.GetName());
 
             // Check for directory and files present
-            if (!Directory.Exists(modsetConfigDir))
-            {
+            if (!Directory.Exists(modsetConfigDir)) {
                 Directory.CreateDirectory(modsetConfigDir);
             }
 

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -116,7 +116,7 @@ namespace ArmaServerManager {
         }
 
         /// <summary>
-        /// Performs replacement of a value for correspoinding key in given config file (as string)
+        /// Performs replacement of a value for corresponding key in given config file (as string)
         /// </summary>
         private string ReplaceValue(string config, string key, string value) {
             // Build regex expression with new line before key to prevent mid-line replacements
@@ -127,7 +127,7 @@ namespace ArmaServerManager {
             // Check if $key contains '[]' eg. 'admins[]' as then it's value should be an array
             if (Regex.IsMatch(key, @"[[\]]")) {
                 // Make some magic to replace [] in expression to \[\]
-                expression = Regex.Replace(key, @"\[\]", @"\[\]");
+                expression = Regex.Replace(expression, @"\[\]", @"\[\]");
             }
 
             expression = $"{expression} = .*;";
@@ -147,11 +147,9 @@ namespace ArmaServerManager {
                 quote = "\"";
             }
 
-            if (Regex.IsMatch(key, @"[[\]]")) {
-                config = Regex.Replace(config, expression, $"{key} = {{{value}}};");
-            } else {
-                config = Regex.Replace(config, expression, $"\n{key} = {quote}{value}{quote};");
-            }
+            var replacement = Regex.IsMatch(key, @"[[\]]") ? $"\n{key} = {{{value}}};" : $"\n{key} = {quote}{value}{quote};";
+            config = Regex.Replace(config, expression, replacement);
+            Console.WriteLine($"\"{match.ToString().Substring(1)}\" => \"{replacement.Substring(1)}\"");
 
             return config;
         }

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Newtonsoft.Json;
 using Microsoft.Extensions.Configuration;
 
 namespace ArmaServerManager {
@@ -64,6 +65,24 @@ namespace ArmaServerManager {
         {
             // Get modset config directory based on serverConfig
             var modsetConfigDir = _serverConfigDir + $"\\modsetConfigs\\{_modset.GetName()}";
+
+            // Check for directory and files present
+            if (!Directory.Exists(modsetConfigDir)) {
+                Directory.CreateDirectory(modsetConfigDir);
+            }
+            if (!File.Exists($"{modsetConfigDir}\\config.json")) {
+                // Set hostName according to pattern
+                var sampleServer = new Dictionary<string, string>();
+                sampleServer.Add("hostName", string.Format(Environment.GetEnvironmentVariable("hostNamePattern"), _modset.GetName()));
+                var sampleJSON = new Dictionary<string, Dictionary<string, string>>();
+                sampleJSON.Add("server", sampleServer);
+                // Write to file
+                using (StreamWriter file = File.CreateText($"{modsetConfigDir}\\config.json")) {
+                    JsonSerializer serializer = new JsonSerializer();
+                    serializer.Formatting = Formatting.Indented;
+                    serializer.Serialize(file, sampleJSON);
+                }
+            }
 
             // Load modset specific config from JSON
             _modsetConfig = new ConfigurationBuilder()

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ArmaServerManager {
+    public class ServerConfig
+    {
+        private readonly Settings _settings;
+        private readonly Modset _modset;
+        private string _serverConfigDir;
+
+        /// <summary>
+        /// Class prepares server configuration for given modset
+        /// </summary>
+        /// <param name="settings">Server Settings Object</param>
+        /// <param name="modset">Modset object</param>
+        public ServerConfig(Settings settings, Modset modset)
+        {
+            Console.WriteLine("Loading ServerConfig.");
+            _settings = settings;
+            _modset = modset;
+            // Load config directory and create if it not exists
+            PrepareModsetConfig();
+
+            Console.WriteLine("ServerConfig loaded.");
+        }
+
+        /// <summary>
+        /// Prepares common serverConfig directory and files
+        /// </summary>
+        private string PrepareServerConfig()
+        {
+            var serverPath = _settings.GetServerPath();
+            var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
+            _serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
+            if (Directory.Exists(_serverConfigDir)) return _serverConfigDir;
+            Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
+            Directory.CreateDirectory(_serverConfigDir);
+            // Check if common server configs are in place
+            var filesList = new List<string>() { "basic.cfg", "server.cfg", "common.Arma3Profile", "common.json" };
+            foreach (var fileName in filesList)
+            {
+                var filePath = $"{_serverConfigDir}\\{fileName}";
+                if (File.Exists(filePath)) continue;
+                Console.WriteLine($"{fileName} not found, copying.");
+                File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
+            }
+            return _serverConfigDir;
+        }
+
+        /// <summary>
+        /// Prepares modset specific config directory and files.
+        /// </summary>
+        private void PrepareModsetConfig()
+        {
+            // Get modset config directory based on serverConfig
+            var modsetConfigDir = PrepareServerConfig() + $"modsetConfigs\\{_modset.GetName()}";
+
+        }
+    }
+
+}

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -41,7 +41,7 @@ namespace ArmaServerManager {
         {
             var serverPath = _settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
-            var serverConfigDir = $"{serverPath}\\{serverConfigDirName}";
+            var serverConfigDir = Path.Join(serverPath, serverConfigDirName);
             if (!Directory.Exists(_serverConfigDir))
             {
                 Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
@@ -63,11 +63,10 @@ namespace ArmaServerManager {
         {
             var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
             foreach (var fileName in filesList)
-            {
-                var destFileName = path + $"\\{fileName}";
+                var destFileName = Path.Join(path, fileName);
                 if (File.Exists(destFileName)) continue;
                 Console.WriteLine($"{fileName} not found, copying.");
-                File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", destFileName);
+                File.Copy(Path.Join(Directory.GetCurrentDirectory(), $"example_{fileName}"), destFileName);
             }
         }
 
@@ -77,7 +76,7 @@ namespace ArmaServerManager {
         private void PrepareModsetConfig() {
             var modsetConfigDir = PrepareModsetConfigDir();
 
-            if (!File.Exists($"{modsetConfigDir}\\config.json")) {
+            if (!File.Exists(Path.Join(modsetConfigDir, "config.json"))) {
                 // Set hostName according to pattern
                 var sampleServer = new Dictionary<string, string>();
                 sampleServer.Add("hostName",
@@ -85,7 +84,7 @@ namespace ArmaServerManager {
                 var sampleJSON = new Dictionary<string, Dictionary<string, string>>();
                 sampleJSON.Add("server", sampleServer);
                 // Write to file
-                using (StreamWriter file = File.CreateText($"{modsetConfigDir}\\config.json")) {
+                using (StreamWriter file = File.CreateText(Path.Join(modsetConfigDir, "config.json"))) {
                     JsonSerializer serializer = new JsonSerializer();
                     serializer.Formatting = Formatting.Indented;
                     serializer.Serialize(file, sampleJSON);
@@ -103,7 +102,7 @@ namespace ArmaServerManager {
                 Console.WriteLine($"Loading {config}.cfg for {_modset.GetName()} modset.");
                 var cfgFile = FillCfg(File.ReadAllText($"{_serverConfigDir}\\{config}.cfg"),
                     _modsetConfig.GetSection(config));
-                File.WriteAllText($"{modsetConfigDir}\\{config}.cfg", cfgFile);
+                File.WriteAllText(Path.Join(modsetConfigDir, $"{config}.cfg"), cfgFile);
                 Console.WriteLine($"{config}.cfg successfully exported to {modsetConfigDir}");
             }
         }
@@ -111,7 +110,7 @@ namespace ArmaServerManager {
         private string PrepareModsetConfigDir()
         {
             // Get modset config directory based on serverConfig
-            var modsetConfigDir = _serverConfigDir + $"\\modsetConfigs\\{_modset.GetName()}";
+            var modsetConfigDir = Path.Join(_serverConfigDir, "modsetConfigs", _modset.GetName());
 
             // Check for directory and files present
             if (!Directory.Exists(modsetConfigDir))

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Extensions.Configuration;
 
 namespace ArmaServerManager {
     public class ServerConfig
@@ -8,6 +9,7 @@ namespace ArmaServerManager {
         private readonly Settings _settings;
         private readonly Modset _modset;
         private string _serverConfigDir;
+        private IConfigurationRoot _commonConfig;
 
         /// <summary>
         /// Class prepares server configuration for given modset
@@ -20,6 +22,7 @@ namespace ArmaServerManager {
             _settings = settings;
             _modset = modset;
             // Load config directory and create if it not exists
+            PrepareServerConfig();
             PrepareModsetConfig();
 
             Console.WriteLine("ServerConfig loaded.");
@@ -28,7 +31,7 @@ namespace ArmaServerManager {
         /// <summary>
         /// Prepares common serverConfig directory and files
         /// </summary>
-        private string PrepareServerConfig()
+        private void PrepareServerConfig()
         {
             var serverPath = _settings.GetServerPath();
             var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
@@ -46,7 +49,11 @@ namespace ArmaServerManager {
                 Console.WriteLine($"{fileName} not found, copying.");
                 File.Copy($"{Directory.GetCurrentDirectory()}\\example_{fileName}", filePath);
             }
-            return _serverConfigDir;
+            // Load common config from JSON
+            _commonConfig = new ConfigurationBuilder()
+                .SetBasePath(_serverConfigDir)
+                .AddJsonFile("common.json")
+                .Build();
         }
 
         /// <summary>

--- a/ArmaServerManager/ServerConfig.cs
+++ b/ArmaServerManager/ServerConfig.cs
@@ -137,55 +137,13 @@ namespace ArmaServerManager {
                 if (value.Count != 0) {
                     // If value is array, it needs changing to string
                     var stringValue = String.Join(", ", value.Select(p => p.Value.ToString()));
-                    cfgFile = ReplaceValue(cfgFile, key, stringValue);
+                    cfgFile = ServerConfigReplacer.ReplaceValue(cfgFile, key, stringValue);
                 } else {
-                    cfgFile = ReplaceValue(cfgFile, key, config[key]);
+                    cfgFile = ServerConfigReplacer.ReplaceValue(cfgFile, key, config[key]);
                 }
             }
 
             return cfgFile;
-        }
-
-        /// <summary>
-        /// Performs replacement of a value for corresponding key in given config file (as string)
-        /// </summary>
-        public static string ReplaceValue(string config, string key, string value) {
-            // Build regex expression with new line before key to prevent mid-line replacements
-            var expression = $"\n{key}";
-            if (key == "template") {
-                expression = $"\t\t{key}";
-            }
-
-            // Check if $key contains '[]' eg. 'admins[]' as then it's value should be an array
-            if (Regex.IsMatch(key, @"[[\]]")) {
-                // Make some magic to replace [] in expression to \[\]
-                expression = Regex.Replace(expression, @"\[\]", @"\[\]");
-            }
-
-            expression = $"{expression} = .*;";
-            // If expression is not found, return unchanged config
-            if (!Regex.IsMatch(config, expression)) {
-                return config;
-            }
-
-            // Check character after "key = "
-            // eg. for key = 'lobbyTimeout' and config entry:
-            // lobbyTimeout = 1234
-            // returns 1
-            // Used to determine if there are quotation marks needed
-            var quote = "";
-            var match = Regex.Match(config, expression);
-            if (match.Value.Substring(key.Length + 4, 1) == "\"") {
-                quote = "\"";
-            }
-
-            var replacement = Regex.IsMatch(key, @"[[\]]")
-                ? $"\n{key} = {{{value}}};"
-                : $"\n{key} = {quote}{value}{quote};";
-            config = Regex.Replace(config, expression, replacement);
-            Console.WriteLine($"\"{match.ToString().Substring(1)}\" => \"{replacement.Substring(1)}\"");
-
-            return config;
         }
     }
 }

--- a/ArmaServerManager/ServerConfigReplacer.cs
+++ b/ArmaServerManager/ServerConfigReplacer.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace ArmaServerManager {
+    public class ServerConfigReplacer {
+        /// <summary>
+        /// Performs replacement of a value for corresponding key in given config file (as string)
+        /// </summary>
+        public static string ReplaceValue(string config, string key, string value) {
+            // Build regex expression with new line before key to prevent mid-line replacements
+            var expression = $"\n{key}";
+            if (key == "template") {
+                expression = $"\t\t{key}";
+            }
+
+            // Check if $key contains '[]' eg. 'admins[]' as then it's value should be an array
+            if (Regex.IsMatch(key, @"[[\]]")) {
+                // Make some magic to replace [] in expression to \[\]
+                expression = Regex.Replace(expression, @"\[\]", @"\[\]");
+            }
+
+            expression = $"{expression} = .*;";
+            // If expression is not found, return unchanged config
+            if (!Regex.IsMatch(config, expression)) {
+                return config;
+            }
+
+            // Check character after "key = "
+            // eg. for key = 'lobbyTimeout' and config entry:
+            // lobbyTimeout = 1234
+            // returns 1
+            // Used to determine if there are quotation marks needed
+            var quote = "";
+            var match = Regex.Match(config, expression);
+            if (match.Value.Substring(key.Length + 4, 1) == "\"") {
+                quote = "\"";
+            }
+
+            var replacement = Regex.IsMatch(key, @"[[\]]")
+                ? $"\n{key} = {{{value}}};"
+                : $"\n{key} = {quote}{value}{quote};";
+            config = Regex.Replace(config, expression, replacement);
+            Console.WriteLine($"\"{match.ToString().Substring(1)}\" => \"{replacement.Substring(1)}\"");
+
+            return config;
+        }
+    }
+}

--- a/ArmaServerManager/Settings.cs
+++ b/ArmaServerManager/Settings.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Win32;
+
+namespace ArmaServerManager {
+
+    public class Settings
+    {
+        private static IConfigurationRoot _config;
+        private readonly string _executable = "arma3server_x64.exe";
+        private readonly string _serverPath;
+
+        public Settings()
+        {
+            Console.WriteLine("Loading Manager Settings.");
+            // Load config
+            _config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("settings.json")
+                .AddEnvironmentVariables()
+                .Build();
+            // Load serverPath
+            try
+            {
+                _serverPath = _config["serverPath"];
+            }
+            catch (NullReferenceException)
+            {
+                _serverPath = Registry.LocalMachine
+                    .OpenSubKey("SOFTWARE\\WOW6432Node\\bohemia interactive\\arma 3")
+                    ?.GetValue("main")
+                    .ToString();
+            }
+        }
+
+        public object GetSettingsValue(string key)
+        {
+            try
+            {
+                return _config[key];
+            }
+            catch (NullReferenceException)
+            {
+                return null;
+            }
+        }
+
+        public string GetServerPath()
+        {
+            return _serverPath;
+        }
+
+        public string GetServerExePath()
+        {
+            return _serverPath != null ? $"{_serverPath}\\{_executable}" : null;
+        }
+    }
+
+}

--- a/ArmaServerManager/Settings.cs
+++ b/ArmaServerManager/Settings.cs
@@ -1,23 +1,24 @@
 ﻿using System;
-using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Win32;
 
 namespace ArmaServerManager {
-    public class Settings {
+    public interface ISettings
+    {
+        object GetSettingsValue(string key);
+        string GetServerPath();
+        string GetServerExePath();
+    }
+
+    public class Settings : ISettings
+    {
         private static IConfigurationRoot _config;
         private readonly string _executable = "arma3server_x64.exe";
         private readonly string _serverPath;
 
-        public Settings() {
+        public Settings(IConfigurationRoot config) {
             Console.WriteLine("Loading Manager Settings.");
-            // Load config
-            _config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("settings.json")
-                .AddEnvironmentVariables()
-                .Build();
-            // Load serverPath
+            _config = config;
             try {
                 _serverPath = _config["serverPath"];
             } catch (NullReferenceException) {

--- a/ArmaServerManager/Settings.cs
+++ b/ArmaServerManager/Settings.cs
@@ -4,15 +4,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Win32;
 
 namespace ArmaServerManager {
-
-    public class Settings
-    {
+    public class Settings {
         private static IConfigurationRoot _config;
         private readonly string _executable = "arma3server_x64.exe";
         private readonly string _serverPath;
 
-        public Settings()
-        {
+        public Settings() {
             Console.WriteLine("Loading Manager Settings.");
             // Load config
             _config = new ConfigurationBuilder()
@@ -21,12 +18,9 @@ namespace ArmaServerManager {
                 .AddEnvironmentVariables()
                 .Build();
             // Load serverPath
-            try
-            {
+            try {
                 _serverPath = _config["serverPath"];
-            }
-            catch (NullReferenceException)
-            {
+            } catch (NullReferenceException) {
                 _serverPath = Registry.LocalMachine
                     .OpenSubKey("SOFTWARE\\WOW6432Node\\bohemia interactive\\arma 3")
                     ?.GetValue("main")
@@ -34,27 +28,20 @@ namespace ArmaServerManager {
             }
         }
 
-        public object GetSettingsValue(string key)
-        {
-            try
-            {
+        public object GetSettingsValue(string key) {
+            try {
                 return _config[key];
-            }
-            catch (NullReferenceException)
-            {
+            } catch (NullReferenceException) {
                 return null;
             }
         }
 
-        public string GetServerPath()
-        {
+        public string GetServerPath() {
             return _serverPath;
         }
 
-        public string GetServerExePath()
-        {
+        public string GetServerExePath() {
             return _serverPath != null ? $"{_serverPath}\\{_executable}" : null;
         }
     }
-
 }

--- a/ArmaServerManager/example_basic.cfg
+++ b/ArmaServerManager/example_basic.cfg
@@ -1,0 +1,41 @@
+class sockets {
+    // Packet MTU, keep lower than 1500 to not risk packet fragmentation, default 1400
+    maxPacketSize = 1444; // 1444 like official BI servers
+    // Initial negotiated client connection speed in bytes, default 32000 (256 kbit)
+    initBandwidth = 1250000; // 10 Mbit
+    // Minimal negotiated client connection speed in bytes, default 8000 (64 kbit)
+    MinBandwidth = 65536; // 512 kbit, even people in the middle of nowhere should get this these days
+    // Maximal negotiated client connection speed in bytes, default 2000000 (16 Mbit)
+    MaxBandwidth = 2000000;
+};
+
+adapter = -1;
+3D_Performance = 1;
+Resolution_W = 0;
+Resolution_H = 0;
+Resolution_Bpp = 32;
+terrainGrid = 25;
+viewDistance = 3000;
+Windowed = 0;
+
+// These options are important for performance tuning
+
+// Bandwidth the server is guaranteed to have (in bps). This value helps server to estimate bandwidth available. Increasing it to too optimistic values can increase lag and CPU load, as too many messages will be sent but discarded. 
+// Default: 131072 (128 kbit)
+MinBandwidth = 768000; // 750 kbit
+// Bandwidth the server is guaranteed to never have. This value helps the server to estimate bandwidth available.
+MaxBandwidth = 52428800;
+
+// Maximum number of messages that can be sent in one simulation cycle. Increasing this value can decrease lag on high upload bandwidth servers. Default: 128
+MaxMsgSend = 640; // 640 like official BI servers
+// Maximum size of guaranteed packet in bytes (without headers). Small messages are packed to larger frames. Guaranteed messages are used for non-repetitive events like shooting. Default: 512
+MaxSizeGuaranteed = 512;
+// Maximum size of non-guaranteed packet in bytes (without headers). Non-guaranteed messages are used for repetitive updates like soldier or vehicle position. Increasing this value may improve bandwidth requirement, but it may increase lag. Default: 256
+MaxSizeNonguaranteed = 256;
+
+// Minimal error to send updates across network. Using a smaller value can make units observed by binoculars or sniper rifle to move smoother. Default: 0.001
+MinErrorToSend = 0.001;
+// Minimal error to send updates across network for near units. Using larger value can reduce traffic sent for near units. Used to control client to server traffic as well. Default: 0.01
+MinErrorToSendNear = 0.01;
+// (bytes) Users with custom face or custom sound larger than this size are kicked when trying to connect.
+MaxCustomFileSize = 1310720;

--- a/ArmaServerManager/example_common.Arma3Profile
+++ b/ArmaServerManager/example_common.Arma3Profile
@@ -1,0 +1,56 @@
+userOverride=0;
+version=1;
+blood=1;
+singleVoice=0;
+gamma=1;
+brightness=1;
+maxSamplesPlayed=96;
+difficulty="custom";
+class DifficultyPresets
+{
+        class CustomDifficulty
+        {
+                class Options
+                {
+                        groupIndicators=0;
+                        friendlyTags=0;
+                        enemyTags=0;
+                        detectedMines=0;
+                        commands=0;
+                        waypoints=0;
+                        weaponInfo=2;
+                        stanceIndicator=2;
+                        reducedDamage=0;
+                        staminaBar=1;
+                        weaponCrosshair=0;
+                        visionAid=0;
+                        thirdPersonView=0;
+                        cameraShake=1;
+                        scoreTable=0;
+                        deathMessages=0;
+                        vonID=1;
+                        mapContentFriendly=0;
+                        mapContentEnemy=0;
+                        mapContentMines=0;
+                        autoReport=0;
+                        multipleSaves=0;
+                        tacticalPing=0;
+                };
+                aiLevelPreset=3;
+                class CustomAILevel
+                {
+                        skillAI=0.89999998;
+                        precisionAI=0.2;
+                };
+        };
+};
+sceneComplexity=400000;
+shadowZDistance=100;
+viewDistance=1000;
+preferredObjectViewDistance=800;
+terrainGrid=25;
+volumeCD=10;
+volumeFX=10;
+volumeSpeech=10;
+volumeVoN=10;
+vonRecThreshold=0.029999999;

--- a/ArmaServerManager/example_common.json
+++ b/ArmaServerManager/example_common.json
@@ -1,0 +1,22 @@
+{
+	"basic": {
+		"MinBandwidth": 131072,
+		"MaxBandwidth": 52428800,
+        
+		"MaxMsgSend": 128,
+		"MaxSizeGuaranteed": 512,
+		"MaxSizeNonguaranteed": 256,
+
+		"MinErrorToSend": 0.001,
+		"MinErrorToSendNear": 0.01,
+		"MaxCustomFileSize": 1310720
+	},
+
+	"server": {
+		"hostName": "My fun server",
+		"password": "nopassword",
+		"passwordAdmin": "noadminpassword",
+		"serverCommandPassword": "nocommandpassword",
+		"admins[]": ["\"123\"","\"456\""]
+	}
+}

--- a/ArmaServerManager/example_server.cfg
+++ b/ArmaServerManager/example_server.cfg
@@ -1,0 +1,101 @@
+// GLOBAL SETTINGS
+
+hostName = "My fun server"; // Servername visible in the game browser.
+password = "nopassword"; // Password required to connect to server.
+passwordAdmin = "noadminpassword"; // Password to protect admin access.
+serverCommandPassword = "nocommandpassword"; // Password required by alternate syntax of serverCommand server-side scripting.
+motd[] = {""}; // Welcome message
+motdInterval = 1;
+admins[] = {""}; //e.g. {"1234","5678"} whitelisted client can use #login w/o password (since Arma 3 1.69+).
+headlessClients[] = {127.0.0.1};
+localClient[] = {127.0.0.1};
+logFile = "";
+
+// JOINING RULES
+maxPlayers = 128; // The maximum number of players that can connect to server. The final number will be lesser between number given here and number of mission slots (default value is 64 for dedicated server).
+kickduplicate = 1; // Do not allow duplicate game IDs. Second player with an existing ID will be kicked automatically. 1 means active, 0 disabled.
+verifySignatures = 3; // Enables or disables the signature verification for addons. Default = 2, disabled = 0
+allowedFilePatching = 0; // Prevent or allow file patching for the clients (including the HC) (since Arma 3 1.49+). 0 is no clients (default), 1 is Headless Clients only, 2 is all clients
+
+// VOTING
+voteMissionPlayers = 3; // Start mission-voting when X numberOfPlayers connect. 3 players in this example.
+voteThreshold = 0.33; // Percentage of votes needed to confirm a vote.
+
+// INGAME SETTINGS
+disableVoN = 1; // If set to 1, Voice over Net will not be available
+vonCodec = 1; // If set to 1 then it uses IETF standard OPUS codec, if to 0 then it uses SPEEX codec (since Arma 3 update 1.58+)
+vonCodecQuality = 10; // since 1.62.95417 supports range 1-20 //since 1.63.x will supports range 1-30 //8kHz is 0-10, 16kHz is 11-20, 32kHz(48kHz) is 21-30
+persistent = 0; // If 1, missions still run on even after the last player disconnected.
+timeStampFormat = "short"; // Set the timestamp format used on each report line in server-side RPT file. Possible values are "none" (default),"short","full".
+BattlEye = 0; // Server to use BattlEye system
+
+maxPing = 150; // Max ping value until server kick the user (since Arma 3 1.56+) 
+maxPacketloss = 20; // Max packetloss value until server kick the user (since Arma 3 1.56+) 
+disconnectTimeout = 60; // Server wait time before disconnecting client, default 90 seconds, range 5 to 90 seconds. (since Arma 3 1.56+) 
+// Defines if {<MaxPing>, <MaxPacketLoss>, <MaxDesync>, <DisconnectTimeout>} will be logged (0) or kicked (1)
+kickClientsOnSlowNetwork[] = {0, 0, 0, 1};
+
+// SCRIPTING ISSUES
+doubleIdDetected = "";
+onUserConnected = "";
+onUserDisconnected = "";
+unsafeCVL = 1; //createVehicleLocal was restricted in multiplayer - vehicles, shots, explosions and such are no longer possible to spawn (the old behavior can be turned on via "unsafeCVL=1" in the description.ext or server's config)
+
+// SIGNATURE VERIFICATION
+onUnsignedData = "kick (_this select 0)"; // unsigned data detected
+onHackedData = "kick (_this select 0)"; // tampering of the signature detected
+onDifferentData = "kick (_this select 0)"; // data with a valid signature, but different version than the one present on server detected
+regularCheck = "{}"; // disable mid-mission signature checks (causing random kicks)
+
+// TIMEOUTS SETTINGS
+/* { {kickID, timeout}, ... }
+kickID (type to determine from where the kick originated e.g. admin or votekick etc.)
+
+    0 - manual kick (vote kick, admin kick, bruteforce detection etc.)
+    1 - connectivity kick (ping, timeout, packetloss, desync)
+    2 - BattlEye kick
+    3 - harmless kick (wrong addons, steam timeout or checks, signatures, content etc.)
+
+timeout = in seconds how long until kicked player can return
+
+    >0 seconds
+    -1 until missionEnd
+    -2 until serverRestart
+
+(since Arma 3 1.90+ PerformanceBranch) */
+kickTimeout[] = { {0, 30}, {1, 1}, {2, 1}, {3, 1} };
+votingTimeOut = 60;
+roleTimeOut = 120;
+briefingTimeOut = 60;
+debriefingTimeOut = 45;
+lobbyIdleTimeout = -1;
+missionsToServerRestart = 2;
+
+// MISSION ROTATION
+class Missions
+{
+	class TestMission01
+	{
+		template = MP_Marksmen_01.Altis;
+		difficulty = "custom";
+		class Params {};
+	};
+	class TestMission02
+	{
+		template = MP_End_Game_01.Altis;
+		difficulty = "custom";
+		class Params {};
+	};
+	class TestMission03
+	{
+		template = MP_End_Game_02.Altis;
+		difficulty = "custom";
+		class Params {};
+	};
+	class TestMission04
+	{
+		template = MP_End_Game_03.Altis;
+		difficulty = "custom";
+		class Params {};
+	};
+};

--- a/ArmaServerManager/settings.json
+++ b/ArmaServerManager/settings.json
@@ -1,3 +1,4 @@
 {
+	"serverConfigDirName": "serverConfig",
 	"serverPath": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3"
 }

--- a/ArmaServerManagerTests/ArmaServerManagerTests.csproj
+++ b/ArmaServerManagerTests/ArmaServerManagerTests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/ArmaServerManagerTests/ServerConfigReplacerTests.cs
+++ b/ArmaServerManagerTests/ServerConfigReplacerTests.cs
@@ -8,9 +8,9 @@ using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace ArmaServerManagerTests {
-    public class ServerConfigTests {
+    public class ServerConfigReplacerTests {
         [Fact]
-        public void ServerConfig_ReplaceValue_StringEqual() {
+        public void ReplaceValue_StringEqual() {
             var modsetConfig = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("example_common.json")
@@ -19,14 +19,14 @@ namespace ArmaServerManagerTests {
             var key = "hostName"; // It has it's value as string with quotes
             var value = modsetConfig.GetSection("server")[key];
 
-            var newCfgFile = ServerConfig.ReplaceValue(cfgFile, key, value);
+            var newCfgFile = ServerConfigReplacer.ReplaceValue(cfgFile, key, value);
 
             var match = Regex.IsMatch(newCfgFile, $"{key} = \"{value}\";");
             Assert.True(match);
         }
 
         [Fact]
-        public void ServerConfig_ReplaceValue_NoQuotesEqual() {
+        public void ReplaceValue_NoQuotesEqual() {
             var modsetConfig = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("example_common.json")
@@ -35,14 +35,14 @@ namespace ArmaServerManagerTests {
             var key = "verifySignatures"; // It has it's value as number with no quotes
             var value = modsetConfig.GetSection("server")[key];
 
-            var newCfgFile = ServerConfig.ReplaceValue(cfgFile, key, value);
+            var newCfgFile = ServerConfigReplacer.ReplaceValue(cfgFile, key, value);
 
             var match = Regex.IsMatch(newCfgFile, $"{key} = {value};");
             Assert.True(match);
         }
 
         [Fact]
-        public void ServerConfig_ReplaceValue_ArrayEqual() {
+        public void ReplaceValue_ArrayEqual() {
             var modsetConfig = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("example_common.json")
@@ -52,7 +52,7 @@ namespace ArmaServerManagerTests {
             var value = modsetConfig.GetSection("server").GetSection(key).GetChildren().ToList();
             var stringValue = String.Join(", ", value.Select(p => p.Value.ToString()));
 
-            var newCfgFile = ServerConfig.ReplaceValue(cfgFile, key, stringValue);
+            var newCfgFile = ServerConfigReplacer.ReplaceValue(cfgFile, key, stringValue);
 
             key = @"admins\[\]"; // Change for regex
             var match = Regex.IsMatch(newCfgFile, $"{key} = {{{stringValue}}};");

--- a/ArmaServerManagerTests/ServerConfigReplacerTests.cs
+++ b/ArmaServerManagerTests/ServerConfigReplacerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using ArmaServerManager;
 using Microsoft.Extensions.Configuration;

--- a/ArmaServerManagerTests/ServerConfigTests.cs
+++ b/ArmaServerManagerTests/ServerConfigTests.cs
@@ -7,16 +7,28 @@ namespace ArmaServerManagerTests {
     public class ServerConfigTests {
         [Fact]
         public void ServerConfig_LoadConfig_Success() {
-            var modsetName = new Modset().GetName();
+            var modsetName = "default";
+            var serverConfigDirName = "TestDir";
+            var serverConfigDirPath = Path.Join(Directory.GetCurrentDirectory(), serverConfigDirName);
+            var modsetConfigDirPath = Path.Join(serverConfigDirName, "modsetConfigs", "default");
             var settingsMock = new Mock<ISettings>();
             settingsMock.Setup(settings => settings.GetServerPath()).Returns(Directory.GetCurrentDirectory());
-            settingsMock.Setup(settings => settings.GetSettingsValue("serverConfigDirName")).Returns("TestDir");
+            settingsMock.Setup(settings => settings.GetSettingsValue("serverConfigDirName")).Returns(serverConfigDirName);
             
             var serverConfig = new ServerConfig(settingsMock.Object, modsetName);
             var configLoaded = serverConfig.LoadConfig();
             
-            //todo add asserts for directory structure
             Assert.True(configLoaded.IsSuccess);
+            Assert.True(Directory.Exists(serverConfigDirPath));
+            Assert.True(File.Exists(Path.Join(serverConfigDirPath, "server.cfg")));
+            Assert.True(File.Exists(Path.Join(serverConfigDirPath, "basic.cfg")));
+            Assert.True(File.Exists(Path.Join(serverConfigDirPath, "common.json")));
+            Assert.True(File.Exists(Path.Join(serverConfigDirPath, "common.Arma3Profile")));
+            Assert.True(Directory.Exists(modsetConfigDirPath)); 
+            Assert.True(File.Exists(Path.Join(modsetConfigDirPath, "config.json")));
+
+            // Clear
+            Directory.Delete(serverConfigDirPath, true);
         }
     }
 }

--- a/ArmaServerManagerTests/ServerConfigTests.cs
+++ b/ArmaServerManagerTests/ServerConfigTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using ArmaServerManager;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace ArmaServerManagerTests {
+    public class ServerConfigTests {
+        [Fact]
+        public void ServerConfig_ReplaceValue_StringEqual() {
+            var modsetConfig = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("example_common.json")
+                .Build();
+            var cfgFile = File.ReadAllText($"{Directory.GetCurrentDirectory()}\\example_server.cfg");
+            var key = "hostName"; // It has it's value as string with quotes
+            var value = modsetConfig.GetSection("server")[key];
+
+            var newCfgFile = ServerConfig.ReplaceValue(cfgFile, key, value);
+
+            var match = Regex.IsMatch(newCfgFile, $"{key} = \"{value}\";");
+            Assert.True(match);
+        }
+
+        [Fact]
+        public void ServerConfig_ReplaceValue_NoQuotesEqual() {
+            var modsetConfig = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("example_common.json")
+                .Build();
+            var cfgFile = File.ReadAllText($"{Directory.GetCurrentDirectory()}\\example_server.cfg");
+            var key = "verifySignatures"; // It has it's value as number with no quotes
+            var value = modsetConfig.GetSection("server")[key];
+
+            var newCfgFile = ServerConfig.ReplaceValue(cfgFile, key, value);
+
+            var match = Regex.IsMatch(newCfgFile, $"{key} = {value};");
+            Assert.True(match);
+        }
+
+        [Fact]
+        public void ServerConfig_ReplaceValue_ArrayEqual() {
+            var modsetConfig = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("example_common.json")
+                .Build();
+            var cfgFile = File.ReadAllText($"{Directory.GetCurrentDirectory()}\\example_server.cfg");
+            var key = "admins[]"; // It has array value with {} as array brackets
+            var value = modsetConfig.GetSection("server").GetSection(key).GetChildren().ToList();
+            var stringValue = String.Join(", ", value.Select(p => p.Value.ToString()));
+
+            var newCfgFile = ServerConfig.ReplaceValue(cfgFile, key, stringValue);
+
+            key = @"admins\[\]"; // Change for regex
+            var match = Regex.IsMatch(newCfgFile, $"{key} = {{{stringValue}}};");
+            Assert.True(match);
+        }
+    }
+}

--- a/ArmaServerManagerTests/ServerConfigTests.cs
+++ b/ArmaServerManagerTests/ServerConfigTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace ArmaServerManagerTests {
     public class ServerConfigTests {
         [Fact]
-        public void ServerConfig_Init_Success() {
+        public void ServerConfig_LoadConfig_Success() {
             var modsetName = new Modset().GetName();
             var settings = new Settings();
             var serverConfig = new ServerConfig(settings, modsetName);

--- a/ArmaServerManagerTests/ServerConfigTests.cs
+++ b/ArmaServerManagerTests/ServerConfigTests.cs
@@ -5,8 +5,13 @@ namespace ArmaServerManagerTests {
     public class ServerConfigTests {
         [Fact]
         public void ServerConfig_Init_Success() {
-            var serverConfig = new ServerConfig(new Settings(), new Modset().GetName());
-            Assert.True(true);
+            var modsetName = new Modset().GetName();
+            var settings = new Settings();
+            var serverConfig = new ServerConfig(settings, modsetName);
+            
+            var configLoaded = serverConfig.LoadConfig();
+
+            Assert.True(configLoaded.IsSuccess);
         }
     }
 }

--- a/ArmaServerManagerTests/ServerConfigTests.cs
+++ b/ArmaServerManagerTests/ServerConfigTests.cs
@@ -1,4 +1,6 @@
-﻿using ArmaServerManager;
+﻿using System.IO;
+using ArmaServerManager;
+using Moq;
 using Xunit;
 
 namespace ArmaServerManagerTests {
@@ -6,11 +8,14 @@ namespace ArmaServerManagerTests {
         [Fact]
         public void ServerConfig_LoadConfig_Success() {
             var modsetName = new Modset().GetName();
-            var settings = new Settings();
-            var serverConfig = new ServerConfig(settings, modsetName);
+            var settingsMock = new Mock<ISettings>();
+            settingsMock.Setup(settings => settings.GetServerPath()).Returns(Directory.GetCurrentDirectory());
+            settingsMock.Setup(settings => settings.GetSettingsValue("serverConfigDirName")).Returns("TestDir");
             
+            var serverConfig = new ServerConfig(settingsMock.Object, modsetName);
             var configLoaded = serverConfig.LoadConfig();
-
+            
+            //todo add asserts for directory structure
             Assert.True(configLoaded.IsSuccess);
         }
     }

--- a/ArmaServerManagerTests/ServerConfigTests.cs
+++ b/ArmaServerManagerTests/ServerConfigTests.cs
@@ -1,0 +1,12 @@
+﻿using ArmaServerManager;
+using Xunit;
+
+namespace ArmaServerManagerTests {
+    public class ServerConfigTests {
+        [Fact]
+        public void ServerConfig_Init_Success() {
+            var serverConfig = new ServerConfig(new Settings(), new Modset().GetName());
+            Assert.True(true);
+        }
+    }
+}

--- a/ArmaServerManagerTests/ServerTests.cs
+++ b/ArmaServerManagerTests/ServerTests.cs
@@ -2,8 +2,7 @@
 using Xunit;
 
 namespace ArmaServerManagerTests {
-    public class ServerTests
-    {
+    public class ServerTests {
         [Fact]
         public void Server_IsRunningBeforeStart_Success() {
             Server server = new Server();

--- a/ArmaServerManagerTests/ServerTests.cs
+++ b/ArmaServerManagerTests/ServerTests.cs
@@ -1,0 +1,30 @@
+﻿using ArmaServerManager;
+using Xunit;
+
+namespace ArmaServerManagerTests {
+    public class ServerTests
+    {
+        [Fact]
+        public void Server_IsRunningBeforeStart_Success() {
+            Server server = new Server();
+            Assert.False(server.IsServerRunning());
+        }
+
+        [Fact]
+        public void Server_IsRunningAfterStart_Success() {
+            Server server = new Server();
+            server.Start();
+            Assert.True(server.IsServerRunning());
+            server.Shutdown();
+        }
+
+        [Fact]
+        public void Server_Shutdown_Success() {
+            Server server = new Server();
+            server.Start();
+            server.WaitUntilStarted();
+            server.Shutdown();
+            Assert.False(server.IsServerRunning());
+        }
+    }
+}

--- a/ArmaServerManagerTests/SettingsTests.cs
+++ b/ArmaServerManagerTests/SettingsTests.cs
@@ -1,13 +1,10 @@
 using ArmaServerManager;
 using Xunit;
 
-namespace ArmaServerManagerTests
-{
-    public class SettingsTests
-    {
+namespace ArmaServerManagerTests {
+    public class SettingsTests {
         [Fact]
-        public void Settings_ServerExePath_NotNull()
-        {
+        public void Settings_ServerExePath_NotNull() {
             Settings serverSettings = new Settings();
             Assert.NotNull(serverSettings.GetServerExePath());
         }

--- a/ArmaServerManagerTests/SettingsTests.cs
+++ b/ArmaServerManagerTests/SettingsTests.cs
@@ -1,11 +1,17 @@
+using System.IO;
 using ArmaServerManager;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace ArmaServerManagerTests {
     public class SettingsTests {
         [Fact]
         public void Settings_ServerExePath_NotNull() {
-            Settings serverSettings = new Settings();
+            Settings serverSettings = new Settings(new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("settings.json")
+                .AddEnvironmentVariables()
+                .Build());
             Assert.NotNull(serverSettings.GetServerExePath());
         }
     }

--- a/ArmaServerManagerTests/SettingsTests.cs
+++ b/ArmaServerManagerTests/SettingsTests.cs
@@ -1,5 +1,4 @@
 using ArmaServerManager;
-using System;
 using Xunit;
 
 namespace ArmaServerManagerTests
@@ -11,33 +10,6 @@ namespace ArmaServerManagerTests
         {
             Settings serverSettings = new Settings();
             Assert.NotNull(serverSettings.GetServerExePath());
-        }
-    }
-
-    public class ServerTests {
-        [Fact]
-        public void Server_IsRunningBeforeStart_Success()
-        {
-            Server server = new Server();
-            Assert.False(server.IsServerRunning());
-        }
-
-        [Fact]
-        public void Server_IsRunningAfterStart_Success() {
-            Server server = new Server();
-            server.Start();
-            Assert.True(server.IsServerRunning());
-            server.Shutdown();
-        }
-
-        [Fact]
-        public void Server_Shutdown_Success()
-        {
-            Server server = new Server();
-            server.Start();
-            server.WaitUntilStarted();
-            server.Shutdown();
-            Assert.False(server.IsServerRunning());
         }
     }
 }


### PR DESCRIPTION
When merged this PR will:
- [x] Implement serverConfig directory for arma server configuration files and modsets data including modset specific server configuration.
- [x] Include default server configuration files
- [x] Ability to replace values in configuration files
- [x] Implement basic console logging for all operations (will be easier to implement proper logging later)
- [x] Separate classes to files
- [x] Implement ServerConfig.ReplaceValue() tests for most common key-value types.
- [x] Reformat code in whole solution

Server configuration is prepared for given modset:
- First we make sure default configuration is present. If not, we copy it and create `serverConfig` directory.
- Next we check if there is modset specific directory and config present. If not new one gets created, only with `hostName` entry created from pattern given in `hostNamePattern` environmental variable and modset name, eg. for pattern: `Arma {0} Server` and `default` modset name we get `Arma default server`.
- Then we merge modset specific `config.json` on top of `common.json` so it overwrites where needed.
- Next up we fill `server.cfg` and `basic.cfg` with values from builded configuration. `ServerConfig.ReplaceValues()` is used for each key-value replacement separately.