### PR TITLE
Configuration refactor

### DIFF
--- a/Arma.Server.Manager/Program.cs
+++ b/Arma.Server.Manager/Program.cs
@@ -4,13 +4,12 @@ using Arma.Server.Modlist;
 namespace Arma.Server.Manager {
     internal class Program {
         static void Main(string[] args) {
-            var _settings = new Settings();
+            ISettings settings = new Settings();
             var baseUrl = "https://dev.armaforces.com/";
             var apiService = new ApiModlistDataService(baseUrl);
             var modlist = apiService.GetModlistDataByName("default-test");
-            var modlistConfig = new ModlistConfig(settings, modlist.Name);
-            modlistConfig.LoadConfig();
-            var server = new Server(_settings, modlistConfig);
+            IModlistConfig modlistConfig = new ModlistConfig(settings, modlist.Name);
+            var server = new Server(settings, modlistConfig);
             server.Start();
             server.WaitUntilStarted();
             server.Shutdown();

--- a/Arma.Server.Manager/Program.cs
+++ b/Arma.Server.Manager/Program.cs
@@ -5,10 +5,12 @@ namespace Arma.Server.Manager {
     internal class Program {
         static void Main(string[] args) {
             ISettings settings = new Settings();
+            settings.LoadSettings();
             var baseUrl = "https://dev.armaforces.com/";
             var apiService = new ApiModlistDataService(baseUrl);
             var modlist = apiService.GetModlistDataByName("default-test");
             IModlistConfig modlistConfig = new ModlistConfig(settings, modlist.Name);
+            modlistConfig.LoadConfig();
             var server = new Server(settings, modlistConfig);
             server.Start();
             server.WaitUntilStarted();

--- a/Arma.Server.Manager/settings.json
+++ b/Arma.Server.Manager/settings.json
@@ -2,5 +2,6 @@
 	"modlistConfigDirName":  "modlistConfig",
 	"modsDirectory":  "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3\\!Workshop",
 	"serverConfigDirectory": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3\\serverConfig",
-	"serverDirectory": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3"
+	"serverDirectory": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3",
+	"serverExecutableName":  "arma3server_x64.exe"
 }

--- a/Arma.Server.Manager/settings.json
+++ b/Arma.Server.Manager/settings.json
@@ -1,4 +1,6 @@
 {
-	"serverConfigDirName": "serverConfig",
-	"serverPath": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3"
+	"modlistConfigDirName":  "modlistConfig",
+	"modsDirectory":  "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3\\!Workshop",
+	"serverConfigDirectory": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3\\serverConfig",
+	"serverDirectory": "P:\\Program Files (x86)\\SteamLibrary\\steamapps\\common\\Arma 3"
 }

--- a/Arma.Server.Test/Arma.Server.Test.csproj
+++ b/Arma.Server.Test/Arma.Server.Test.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="System.IO.Abstractions" Version="2.0.0.138" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.0.0.138" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/Arma.Server.Test/Arma.Server.Test.csproj
+++ b/Arma.Server.Test/Arma.Server.Test.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="System.IO.Abstractions" Version="2.0.0.138" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.0.0.138" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/Arma.Server.Test/Config/ConfigReplacerTests.cs
+++ b/Arma.Server.Test/Config/ConfigReplacerTests.cs
@@ -21,7 +21,6 @@ namespace Arma.Server.Test.Config {
                 .Build();
 
             var jsonString = File.ReadAllText(Path.Join(Directory.GetCurrentDirectory(), "test_common.json"));
-            var JSON = JsonSerializer.Deserialize<Object>(jsonString);
         }
 
         [Fact]

--- a/Arma.Server.Test/Config/ModsetConfigTests.cs
+++ b/Arma.Server.Test/Config/ModsetConfigTests.cs
@@ -40,7 +40,7 @@ namespace Arma.Server.Test.Config {
             var configLoaded = modlistConfig.LoadConfig();
 
             // Assert
-            configLoaded.Should().BeEquivalentTo(Result.Success());
+            configLoaded.IsSuccess.Should().BeTrue();
             Assert.True(Directory.Exists(_modlistConfigDirPath));
             Assert.True(File.Exists(Path.Join(_modlistConfigDirPath, "server.cfg")));
             Assert.True(File.Exists(Path.Join(_modlistConfigDirPath, "basic.cfg")));

--- a/Arma.Server.Test/Config/ModsetConfigTests.cs
+++ b/Arma.Server.Test/Config/ModsetConfigTests.cs
@@ -30,8 +30,8 @@ namespace Arma.Server.Test.Config {
             // Arrange
             var settingsMock = new Mock<ISettings>();
             settingsMock.Setup(settings => settings.ServerDirectory).Returns(Directory.GetCurrentDirectory());
-            settingsMock.Setup(settings => settings.ServerConfigDirectoryName)
-                .Returns(_serverConfigDirName);
+            settingsMock.Setup(settings => settings.ServerConfigDirectory)
+                .Returns(_serverConfigDirPath);
             settingsMock.Setup(settings => settings.ModlistConfigDirectoryName)
                 .Returns(_modlistConfigDirName);
 

--- a/Arma.Server.Test/Config/ModsetConfigTests.cs
+++ b/Arma.Server.Test/Config/ModsetConfigTests.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.IO;
 using Arma.Server.Config;
 using AutoFixture;
+using CSharpFunctionalExtensions;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -10,12 +12,13 @@ namespace Arma.Server.Test.Config {
         private static readonly Fixture Fixture = new Fixture();
         private readonly string _modlistName = Fixture.Create<string>();
         private readonly string _serverConfigDirName = Fixture.Create<string>();
+        private readonly string _modlistConfigDirName = Fixture.Create<string>();
         private readonly string _serverConfigDirPath;
         private readonly string _modlistConfigDirPath;
 
         public ModlistConfigTests() {
             _serverConfigDirPath = Path.Join(Directory.GetCurrentDirectory(), _serverConfigDirName);
-            _modlistConfigDirPath = Path.Join(_serverConfigDirPath, "modlistConfigs", _modlistName);
+            _modlistConfigDirPath = Path.Join(_serverConfigDirPath, _modlistConfigDirName, _modlistName);
         }
 
         public void Dispose() {
@@ -26,16 +29,18 @@ namespace Arma.Server.Test.Config {
         public void ModlistConfig_LoadConfig_Success() {
             // Arrange
             var settingsMock = new Mock<ISettings>();
-            settingsMock.Setup(settings => settings.GetServerPath()).Returns(Directory.GetCurrentDirectory());
-            settingsMock.Setup(settings => settings.GetSettingsValue("serverConfigDirName"))
+            settingsMock.Setup(settings => settings.ServerDirectory).Returns(Directory.GetCurrentDirectory());
+            settingsMock.Setup(settings => settings.ServerConfigDirectoryName)
                 .Returns(_serverConfigDirName);
+            settingsMock.Setup(settings => settings.ModlistConfigDirectoryName)
+                .Returns(_modlistConfigDirName);
 
             // Act
-            var modlistConfig = new ModlistConfig(settingsMock.Object, _modlistName);
+            IModlistConfig modlistConfig = new ModlistConfig(settingsMock.Object, _modlistName);
             var configLoaded = modlistConfig.LoadConfig();
 
             // Assert
-            Assert.True(configLoaded.IsSuccess);
+            configLoaded.Should().BeEquivalentTo(Result.Success());
             Assert.True(Directory.Exists(_modlistConfigDirPath));
             Assert.True(File.Exists(Path.Join(_modlistConfigDirPath, "server.cfg")));
             Assert.True(File.Exists(Path.Join(_modlistConfigDirPath, "basic.cfg")));

--- a/Arma.Server.Test/Config/ServerConfigTests.cs
+++ b/Arma.Server.Test/Config/ServerConfigTests.cs
@@ -24,8 +24,8 @@ namespace Arma.Server.Test.Config {
             // Arrange
             var settingsMock = new Mock<ISettings>();
             settingsMock.Setup(settings => settings.ServerExecutable).Returns(Directory.GetCurrentDirectory());
-            settingsMock.Setup(settings => settings.ServerConfigDirectoryName)
-                .Returns(_serverConfigDirName);
+            settingsMock.Setup(settings => settings.ServerConfigDirectory)
+                .Returns(_serverConfigDirPath);
 
             // Act
             IConfig serverConfig = new ServerConfig(settingsMock.Object);

--- a/Arma.Server.Test/Config/ServerConfigTests.cs
+++ b/Arma.Server.Test/Config/ServerConfigTests.cs
@@ -23,12 +23,12 @@ namespace Arma.Server.Test.Config {
         public void ServerConfig_LoadConfig_Success() {
             // Arrange
             var settingsMock = new Mock<ISettings>();
-            settingsMock.Setup(settings => settings.GetServerPath()).Returns(Directory.GetCurrentDirectory());
-            settingsMock.Setup(settings => settings.GetSettingsValue("serverConfigDirName"))
+            settingsMock.Setup(settings => settings.ServerExecutable).Returns(Directory.GetCurrentDirectory());
+            settingsMock.Setup(settings => settings.ServerConfigDirectoryName)
                 .Returns(_serverConfigDirName);
 
             // Act
-            var serverConfig = new ServerConfig(settingsMock.Object);
+            IConfig serverConfig = new ServerConfig(settingsMock.Object);
             var configLoaded = serverConfig.LoadConfig();
 
             // Assert

--- a/Arma.Server.Test/Config/ServerConfigTests.cs
+++ b/Arma.Server.Test/Config/ServerConfigTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Arma.Server.Config;
 using AutoFixture;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -32,7 +33,7 @@ namespace Arma.Server.Test.Config {
             var configLoaded = serverConfig.LoadConfig();
 
             // Assert
-            Assert.True(configLoaded.IsSuccess);
+            configLoaded.IsSuccess.Should().BeTrue();
             Assert.True(Directory.Exists(_serverConfigDirPath));
             Assert.True(File.Exists(Path.Join(_serverConfigDirPath, "server.cfg")));
             Assert.True(File.Exists(Path.Join(_serverConfigDirPath, "basic.cfg")));

--- a/Arma.Server.Test/Config/SettingsTests.cs
+++ b/Arma.Server.Test/Config/SettingsTests.cs
@@ -1,24 +1,161 @@
 using Arma.Server.Config;
+using AutoFixture;
 using CSharpFunctionalExtensions;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Moq;
 using Xunit;
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 
 namespace Arma.Server.Test.Config {
     public class SettingsTests {
+        private const string DefaultServerExecutable = "arma3server_x64.exe";
+        private Mock<IConfigurationRoot> _configurationMock = new Mock<IConfigurationRoot>();
+        private Fixture _fixture = new Fixture();
+        private MockFileSystem _fileSystemMock = new MockFileSystem();
+        private readonly string _workingDirectory;
+
+        public SettingsTests() {
+            _workingDirectory = Path.Join(Directory.GetCurrentDirectory(), _fixture.Create<string>());
+            _configurationMock.Setup(x => x["serverDirectory"]).Returns(_workingDirectory);
+            _fileSystemMock.AddDirectory(_workingDirectory);
+        }
+        
+        [Fact]
+        public void Settings_LoadSettings_Success() {
+            ISettings settings = new Settings(_configurationMock.Object, _fileSystemMock);
+
+            var loaded = settings.LoadSettings();
+
+            loaded.Should().BeEquivalentTo(Result.Success());
+        }
 
         [Fact]
-        public void Settings_ServerPath_FoundOrThrewException() {
+        public void Settings_ModsDirectoryCustom_Correct() {
+            var expectedModsDirectory = Path.Join(_workingDirectory, _fixture.Create<string>());
+            _configurationMock.Setup(x => x["modsDirectory"]).Returns(expectedModsDirectory);
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ModsDirectory.Should().BeEquivalentTo(expectedModsDirectory);
+        }
+
+        [Fact]
+        public void Settings_ModsDirectoryDefault_Correct() {
+            var expectedModsDirectory = Path.Join(_workingDirectory, "mods");
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ModsDirectory.Should().BeEquivalentTo(expectedModsDirectory);
+        }
+
+        [Fact]
+        public void Settings_ServerConfigDirectoryCustom_Correct() {
+            var expectedServerConfigDirectory = Path.Join(_workingDirectory, _fixture.Create<string>());
+            _configurationMock.Setup(x => x["serverConfigDirectory"]).Returns(expectedServerConfigDirectory);
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ServerConfigDirectory.Should().BeEquivalentTo(expectedServerConfigDirectory);
+        }
+
+        [Fact]
+        public void Settings_ServerConfigDirectoryDefault_Correct() {
+            var expectedServerConfigDirectory = Path.Join(_workingDirectory, "serverConfig");
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ServerConfigDirectory.Should().BeEquivalentTo(expectedServerConfigDirectory);
+        }
+
+        [Fact]
+        public void Settings_ServerDirectoryFromConfig_Correct() {
+            var expectedServerDirectory = _workingDirectory;
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ServerDirectory.Should().BeEquivalentTo(expectedServerDirectory);
+        }
+
+        [Fact]
+        public void Settings_ServerDirectoryFromRegistry_Correct() {
+            _configurationMock.Setup(x => x["serverDirectory"]).Returns(() => null);
+            var expectedServerDirectory = _workingDirectory;
+            var registryReaderMock = new Mock<IRegistryReader>();
+            registryReaderMock.Setup(
+                x => x.GetValueFromLocalMachine(@"SOFTWARE\WOW6432Node\bohemia interactive\arma 3", "main"))
+                .Returns(expectedServerDirectory);
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock, registryReaderMock);
+
+            settings.ServerDirectory.Should().BeEquivalentTo(expectedServerDirectory);
+        }
+
+        [Fact]
+        public void Settings_ServerDirectoryNoCorrect_ThrowsServerNotFound() {
+            _configurationMock.Setup(x => x["serverDirectory"]).Returns(() => null);
+            var registryReaderMock = new Mock<IRegistryReader>();
+
+            Action action = () => PrepareSettings(_configurationMock, _fileSystemMock, registryReaderMock);
+
+            action.Should().Throw<ServerNotFoundException>("Could not find server directory.");
+        }
+
+        [Fact]
+        public void Settings_ServerDirectory_FoundOrThrewException() {
             try {
-                // Act
-                ISettings serverSettings = new Settings();
-                var loaded = serverSettings.LoadSettings();
-                // Assert
-                loaded.Should().BeEquivalentTo(Result.Success());
-                serverSettings.ServerDirectory.Should().NotBeNullOrEmpty();
+                var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+                settings.ServerDirectory.Should().NotBeNullOrEmpty();
             } catch (ServerNotFoundException e) {
-                // Assert if exception
                 Assert.Contains(@"Server path could not be loaded", e.Message);
             }
+        }
+        
+        [Fact]
+        public void Settings_ServerExecutableDefault_Correct() {
+            var expectedServerExecutable = Path.Join(_workingDirectory, DefaultServerExecutable);
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ServerExecutable.Should().BeEquivalentTo(expectedServerExecutable);
+        }
+
+        [Fact]
+        public void Settings_ServerExecutableCustom_Correct() {
+            var serverExecutableName = _fixture.Create<string>();
+            var expectedServerExecutable = Path.Join(_workingDirectory, serverExecutableName);
+            _configurationMock.Setup(x => x["serverExecutableName"]).Returns(serverExecutableName);
+            _fileSystemMock.AddFile(expectedServerExecutable, "");
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ServerExecutable.Should().BeEquivalentTo(expectedServerExecutable);
+        }
+
+        [Fact]
+        public void Settings_ServerExecutableCustomIncorrect_FallsBackToDefault() {
+            var serverExecutableName = _fixture.Create<string>();
+            var expectedServerExecutable = Path.Join(_workingDirectory, DefaultServerExecutable);
+            _configurationMock.Setup(x => x["serverExecutableName"]).Returns(serverExecutableName);
+
+            var settings = PrepareSettings(_configurationMock, _fileSystemMock);
+
+            settings.ServerExecutable.Should().BeEquivalentTo(expectedServerExecutable);
+        }
+
+        private ISettings PrepareSettings(
+            Mock<IConfigurationRoot> configurationMock,
+            IFileSystem fileSystemMock,
+            Mock<IRegistryReader> registryReaderMock = null) {
+            ISettings settings = registryReaderMock is null
+                ? new Settings(configurationMock.Object, fileSystemMock)
+                : new Settings(configurationMock.Object, fileSystemMock, registryReaderMock.Object);
+            settings.LoadSettings();
+
+            return settings;
         }
     }
 }

--- a/Arma.Server.Test/Config/SettingsTests.cs
+++ b/Arma.Server.Test/Config/SettingsTests.cs
@@ -30,7 +30,7 @@ namespace Arma.Server.Test.Config {
 
             var loaded = settings.LoadSettings();
 
-            loaded.Should().BeEquivalentTo(Result.Success());
+            loaded.IsSuccess.Should().BeTrue();
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ModsDirectory.Should().BeEquivalentTo(expectedModsDirectory);
+            settings.ModsDirectory.Should().Be(expectedModsDirectory);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ModsDirectory.Should().BeEquivalentTo(expectedModsDirectory);
+            settings.ModsDirectory.Should().Be(expectedModsDirectory);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ServerConfigDirectory.Should().BeEquivalentTo(expectedServerConfigDirectory);
+            settings.ServerConfigDirectory.Should().Be(expectedServerConfigDirectory);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ServerConfigDirectory.Should().BeEquivalentTo(expectedServerConfigDirectory);
+            settings.ServerConfigDirectory.Should().Be(expectedServerConfigDirectory);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Arma.Server.Test.Config {
             var expectedServerDirectory = _workingDirectory;
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ServerDirectory.Should().BeEquivalentTo(expectedServerDirectory);
+            settings.ServerDirectory.Should().Be(expectedServerDirectory);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock, registryReaderMock);
 
-            settings.ServerDirectory.Should().BeEquivalentTo(expectedServerDirectory);
+            settings.ServerDirectory.Should().Be(expectedServerDirectory);
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ServerExecutable.Should().BeEquivalentTo(expectedServerExecutable);
+            settings.ServerExecutable.Should().Be(expectedServerExecutable);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ServerExecutable.Should().BeEquivalentTo(expectedServerExecutable);
+            settings.ServerExecutable.Should().Be(expectedServerExecutable);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Arma.Server.Test.Config {
 
             var settings = PrepareSettings(_configurationMock, _fileSystemMock);
 
-            settings.ServerExecutable.Should().BeEquivalentTo(expectedServerExecutable);
+            settings.ServerExecutable.Should().Be(expectedServerExecutable);
         }
 
         private ISettings PrepareSettings(

--- a/Arma.Server.Test/Config/SettingsTests.cs
+++ b/Arma.Server.Test/Config/SettingsTests.cs
@@ -1,4 +1,6 @@
 using Arma.Server.Config;
+using CSharpFunctionalExtensions;
+using FluentAssertions;
 using Xunit;
 
 namespace Arma.Server.Test.Config {
@@ -8,9 +10,11 @@ namespace Arma.Server.Test.Config {
         public void Settings_ServerPath_FoundOrThrewException() {
             try {
                 // Act
-                Settings serverSettings = new Settings();
+                ISettings serverSettings = new Settings();
+                var loaded = serverSettings.LoadSettings();
                 // Assert
-                Assert.NotNull(serverSettings.GetServerExePath());
+                loaded.Should().BeEquivalentTo(Result.Success());
+                serverSettings.ServerDirectory.Should().NotBeNullOrEmpty();
             } catch (ServerNotFoundException e) {
                 // Assert if exception
                 Assert.Contains(@"Server path could not be loaded", e.Message);

--- a/Arma.Server.Test/EnumConvert.cs
+++ b/Arma.Server.Test/EnumConvert.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace Arma.Server.Test.Helpers {
+namespace Arma.Server.Test {
     public static class EnumConvert {
         public static string ToEnumString<T>(T value) {
             return JsonConvert.SerializeObject(value).Replace("\"", "");

--- a/Arma.Server.Test/Mod/DeserializationTests.cs
+++ b/Arma.Server.Test/Mod/DeserializationTests.cs
@@ -29,18 +29,18 @@ namespace Arma.Server.Test.Mod {
 
             var mod = JsonConvert.DeserializeObject<Arma.Server.Mod.Mod>(json);
 
-            mod.Id.Should().BeEquivalentTo(_modId);
-            mod.Name.Should().BeEquivalentTo(_modName);
+            mod.Id.Should().Be(_modId);
+            mod.Name.Should().Be(_modName);
             mod.CreatedAt.GetType().Should().Be<DateTime>();
             mod.CreatedAt.Should().BeCloseTo(_modCreatedAt, TimeSpan.FromSeconds(1));
             mod.LastUpdatedAt.GetType().Should().Be<DateTime>();
             mod.LastUpdatedAt.Should().BeCloseTo(_modLastUpdatedAt, TimeSpan.FromSeconds(1));
             mod.Source.GetType().Should().Be<ModSource>();
-            mod.Source.Should().BeEquivalentTo(_modSource);
+            mod.Source.Should().Be(_modSource);
             mod.Type.GetType().Should().Be<ModType>();
-            mod.Type.Should().BeEquivalentTo(_modType);
+            mod.Type.Should().Be(_modType);
             mod.ItemId.Should().Be(_workshopItemId);
-            mod.Directory.Should().BeEquivalentTo(_directory);
+            mod.Directory.Should().Be(_directory);
         }
         
         private Dictionary<string, object> PrepareModDictionary() {

--- a/Arma.Server.Test/Mod/ModSourceTests.cs
+++ b/Arma.Server.Test/Mod/ModSourceTests.cs
@@ -10,7 +10,7 @@ namespace Arma.Server.Test.Mod {
         {
             var _modSource = "steam_workshop";
             var modSource = EnumConvert.ToEnum<ModSource>(_modSource);
-            modSource.Should().BeEquivalentTo(ModSource.SteamWorkshop);
+            modSource.Should().Be(ModSource.SteamWorkshop);
         }
 
         [Fact]
@@ -18,7 +18,7 @@ namespace Arma.Server.Test.Mod {
         {
             var _modSource = "directory";
             var modSource = EnumConvert.ToEnum<ModSource>(_modSource);
-            modSource.Should().BeEquivalentTo(ModSource.Directory);
+            modSource.Should().Be(ModSource.Directory);
         }
     }
 }

--- a/Arma.Server.Test/Mod/ModTypeTests.cs
+++ b/Arma.Server.Test/Mod/ModTypeTests.cs
@@ -10,7 +10,7 @@ namespace Arma.Server.Test.Mod {
         {
             var _modSource = "server_side";
             var modSource = EnumConvert.ToEnum<ModType>(_modSource);
-            modSource.Should().BeEquivalentTo(ModType.ServerSide);
+            modSource.Should().Be(ModType.ServerSide);
         }
 
         [Fact]
@@ -18,7 +18,7 @@ namespace Arma.Server.Test.Mod {
         {
             var _modSource = "required";
             var modSource = EnumConvert.ToEnum<ModType>(_modSource);
-            modSource.Should().BeEquivalentTo(ModType.Required);
+            modSource.Should().Be(ModType.Required);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Arma.Server.Test.Mod {
         {
             var _modSource = "optional";
             var modSource = EnumConvert.ToEnum<ModType>(_modSource);
-            modSource.Should().BeEquivalentTo(ModType.Optional);
+            modSource.Should().Be(ModType.Optional);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Arma.Server.Test.Mod {
         {
             var _modSource = "client_side";
             var modSource = EnumConvert.ToEnum<ModType>(_modSource);
-            modSource.Should().BeEquivalentTo(ModType.ClientSide);
+            modSource.Should().Be(ModType.ClientSide);
         }
     }
 }

--- a/Arma.Server.Test/Modlist/DeserializationTests.cs
+++ b/Arma.Server.Test/Modlist/DeserializationTests.cs
@@ -35,8 +35,8 @@ namespace Arma.Server.Test.Modlist {
 
             var modlist = JsonConvert.DeserializeObject<Arma.Server.Modlist.Modlist>(json);
 
-            modlist.Id.Should().BeEquivalentTo(_modlistId);
-            modlist.Name.Should().BeEquivalentTo(_modlistName);
+            modlist.Id.Should().Be(_modlistId);
+            modlist.Name.Should().Be(_modlistName);
             modlist.CreatedAt.GetType().Should().Be<DateTime>();
             modlist.CreatedAt.Should().BeCloseTo(_modlistCreatedAt, TimeSpan.FromSeconds(1));
             modlist.LastUpdatedAt.GetType().Should().Be<DateTime>();

--- a/Arma.Server.Test/ServerTests.cs
+++ b/Arma.Server.Test/ServerTests.cs
@@ -15,7 +15,7 @@ namespace Arma.Server.Test {
 
         public ServerTests() {
             _settingsMock = new Mock<ISettings>();
-            _settingsMock.Setup(x => x.ServerExecutable).Returns(Directory.GetCurrentDirectory());
+            _settingsMock.Setup(x => x.ServerDirectory).Returns(Directory.GetCurrentDirectory());
             _settingsMock.Setup(x => x.ServerConfigDirectoryName).Returns(_fixture.Create<string>());
             _settingsMock.Setup(x => x.ServerExecutable).Returns(Directory.GetCurrentDirectory());
             _modlistConfigMock = new Mock<ModlistConfig>(_settingsMock.Object, _fixture.Create<string>());

--- a/Arma.Server.Test/ServerTests.cs
+++ b/Arma.Server.Test/ServerTests.cs
@@ -15,9 +15,9 @@ namespace Arma.Server.Test {
 
         public ServerTests() {
             _settingsMock = new Mock<ISettings>();
-            _settingsMock.Setup(x => x.GetServerPath()).Returns(Directory.GetCurrentDirectory());
-            _settingsMock.Setup(x => x.GetSettingsValue("serverConfigDirName")).Returns(_fixture.Create<string>());
-            _settingsMock.Setup(x => x.GetServerExePath()).Returns(Directory.GetCurrentDirectory());
+            _settingsMock.Setup(x => x.ServerExecutable).Returns(Directory.GetCurrentDirectory());
+            _settingsMock.Setup(x => x.ServerConfigDirectoryName).Returns(_fixture.Create<string>());
+            _settingsMock.Setup(x => x.ServerExecutable).Returns(Directory.GetCurrentDirectory());
             _modlistConfigMock = new Mock<ModlistConfig>(_settingsMock.Object, _fixture.Create<string>());
 
             // Create server

--- a/Arma.Server.Test/ServerTests.cs
+++ b/Arma.Server.Test/ServerTests.cs
@@ -15,8 +15,9 @@ namespace Arma.Server.Test {
 
         public ServerTests() {
             _settingsMock = new Mock<ISettings>();
+            var _serverConfigDir = Path.Join(Directory.GetCurrentDirectory(), _fixture.Create<string>());
             _settingsMock.Setup(x => x.ServerDirectory).Returns(Directory.GetCurrentDirectory());
-            _settingsMock.Setup(x => x.ServerConfigDirectoryName).Returns(_fixture.Create<string>());
+            _settingsMock.Setup(x => x.ServerConfigDirectory).Returns(_serverConfigDir);
             _settingsMock.Setup(x => x.ServerExecutable).Returns(Directory.GetCurrentDirectory());
             _modlistConfigMock = new Mock<ModlistConfig>(_settingsMock.Object, _fixture.Create<string>());
 

--- a/Arma.Server/Arma.Server.csproj
+++ b/Arma.Server/Arma.Server.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.IO.Abstractions" Version="2.0.0.138" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Arma.Server/Arma.Server.csproj
+++ b/Arma.Server/Arma.Server.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.IO.Abstractions" Version="2.0.0.138" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Arma.Server/Config/IConfig.cs
+++ b/Arma.Server/Config/IConfig.cs
@@ -2,8 +2,24 @@
 
 namespace Arma.Server.Config {
     public interface IConfig {
-        string GetConfigDir();
+        /// <summary>
+        /// Path to config basic.cfg file.
+        /// </summary>
+        string BasicCfg { get; }
+        
+        /// <summary>
+        /// Path to common.json file.
+        /// </summary>
+        string ConfigJson { get; }
 
-        Result LoadConfig();
+        /// <summary>
+        /// Path to config directory.
+        /// </summary>
+        string DirectoryPath { get; }
+
+        /// <summary>
+        /// Path to config server.cfg file.
+        /// </summary>
+        string ServerCfg { get; }
     }
 }

--- a/Arma.Server/Config/IConfig.cs
+++ b/Arma.Server/Config/IConfig.cs
@@ -21,5 +21,11 @@ namespace Arma.Server.Config {
         /// Path to config server.cfg file.
         /// </summary>
         string ServerCfg { get; }
+
+        /// <summary>
+        /// Performs config loading.
+        /// </summary>
+        /// <returns>Result</returns>
+        Result LoadConfig();
     }
 }

--- a/Arma.Server/Config/IModlistConfig.cs
+++ b/Arma.Server/Config/IModlistConfig.cs
@@ -1,0 +1,24 @@
+﻿namespace Arma.Server.Config {
+    public interface IModlistConfig : IConfig {
+
+        /// <summary>
+        /// Path to config.json file.
+        /// </summary>
+        new string ConfigJson { get; }
+
+        /// <summary>
+        /// Path to Headless Client profile directory.
+        /// </summary>
+        string HCProfileDirectory { get; }
+
+        /// <summary>
+        /// Modlist name for given config.
+        /// </summary>
+        string ModlistName { get; }
+
+        /// <summary>
+        /// Path to Server profile directory.
+        /// </summary>
+        string ServerProfileDirectory { get; }
+    }
+}

--- a/Arma.Server/Config/IRegistryReader.cs
+++ b/Arma.Server/Config/IRegistryReader.cs
@@ -1,0 +1,11 @@
+﻿namespace Arma.Server.Config {
+    public interface IRegistryReader {
+        /// <summary>
+        /// Reads value from registry.
+        /// </summary>
+        /// <param name="subKey"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        object GetValueFromLocalMachine(string subKey, string value);
+    }
+}

--- a/Arma.Server/Config/ISettings.cs
+++ b/Arma.Server/Config/ISettings.cs
@@ -14,9 +14,9 @@ namespace Arma.Server.Config {
         string ModsDirectory { get; }
         
         /// <summary>
-        /// Name of server configuration files directory.
+        /// Path to server configuration files directory.
         /// </summary>
-        string ServerConfigDirectoryName { get; }
+        string ServerConfigDirectory { get; }
 
         /// <summary>
         /// Path pointing to server root folder.

--- a/Arma.Server/Config/ISettings.cs
+++ b/Arma.Server/Config/ISettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Arma.Server.Config {
+﻿using CSharpFunctionalExtensions;
+
+namespace Arma.Server.Config {
     public interface ISettings {
 
         /// <summary>
@@ -31,5 +33,11 @@
         /// Server executable file name, eg. "arma3server_x64.exe".
         /// </summary>
         string ServerExecutableName { get; }
+
+        /// <summary>
+        /// Loads settings from configuration.
+        /// </summary>
+        /// <returns>Result</returns>
+        Result LoadSettings();
     }
 }

--- a/Arma.Server/Config/ISettings.cs
+++ b/Arma.Server/Config/ISettings.cs
@@ -1,7 +1,35 @@
 ﻿namespace Arma.Server.Config {
     public interface ISettings {
-        object GetSettingsValue(string key);
-        string GetServerPath();
-        string GetServerExePath();
+
+        /// <summary>
+        /// Name of modlist configuration files directory.
+        /// </summary>
+        string ModlistConfigDirectoryName { get; }
+
+        /// <summary>
+        /// Path to mods directory.
+        /// </summary>
+        string ModsDirectory { get; }
+        
+        /// <summary>
+        /// Name of server configuration files directory.
+        /// </summary>
+        string ServerConfigDirectoryName { get; }
+
+        /// <summary>
+        /// Path pointing to server root folder.
+        /// </summary>
+        string ServerDirectory { get; }
+
+
+        /// <summary>
+        /// Path to server executable file.
+        /// </summary>
+        string ServerExecutable { get; }
+
+        /// <summary>
+        /// Server executable file name, eg. "arma3server_x64.exe".
+        /// </summary>
+        string ServerExecutableName { get; }
     }
 }

--- a/Arma.Server/Config/ModlistConfig.cs
+++ b/Arma.Server/Config/ModlistConfig.cs
@@ -6,100 +6,91 @@ using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 
 namespace Arma.Server.Config {
-    public class ModlistConfig : IConfig {
+    public class ModlistConfig : IModlistConfig {
+        public string BasicCfg { get; protected set; }
+        public string ConfigJson { get; protected set; }
+        public string DirectoryPath { get; protected set; }
+        public string HCProfileDirectory { get; protected set; }
+        public string ModlistName { get; protected set; }
+        public string ServerCfg { get; protected set; }
+        public string ServerProfileDirectory { get; protected set; }
+
         private readonly IConfig _serverConfig;
-        private readonly string _modlistConfigDirPath;
-        private readonly string _modlistName;
         private readonly ISettings _settings;
 
         public ModlistConfig(ISettings settings, string modlistName) {
             _settings = settings;
             _serverConfig = new ServerConfig(_settings);
-            _serverConfig.LoadConfig();
-            _modlistName = modlistName;
-            _modlistConfigDirPath = CreateModlistConfigDirPath();
+            ModlistName = modlistName;
+            LoadConfig();
         }
 
-        public string GetConfigDir() {
-            return _modlistConfigDirPath;
+        private Result LoadConfig() {
+            DirectoryPath = CreateModlistConfigDirPath();
+            ConfigJson = Path.Join(DirectoryPath, "config.json");
+            BasicCfg = Path.Join(DirectoryPath, "basic.cfg");
+            ServerCfg = Path.Join(DirectoryPath, "server.cfg");
+            HCProfileDirectory = Path.Join(DirectoryPath, "profiles", "HC");
+            ServerProfileDirectory = Path.Join(DirectoryPath, "profiles", "Server");
+            return GetOrCreateModlistConfigDir()
+                .OnFailure(() => CreateConfigJson())
+                .Bind(PrepareModlistConfig);
         }
 
-        private string CreateModlistConfigDirPath() {
-            return Path.Join(_serverConfig.GetConfigDir(), "modlistConfigs", _modlistName);
-        }
-
-        public string GetServerCfgPath() {
-            return Path.Join(_modlistConfigDirPath, "server.cfg");
-        }
-
-        public string GetBasicCfgPath() {
-            return Path.Join(_modlistConfigDirPath, "basic.cfg");
-        }
-
-        public string GetServerProfileDir() {
-            return Path.Join(_modlistConfigDirPath, "profiles", "server");
-        }
-
-        public string GetHCProfileDir() {
-            return Path.Join(_modlistConfigDirPath, "profiles", "HC");
-        }
-
-        public Result LoadConfig() {
-            return GetOrCreateModlistConfigDir(_serverConfig.GetConfigDir(), _modlistName)
-                .Bind(() => PrepareModlistConfig(_modlistConfigDirPath, _modlistName));
-        }
+        private string CreateModlistConfigDirPath()
+            => Path.Join(_serverConfig.DirectoryPath, _settings.ModlistConfigDirectoryName, ModlistName);
 
         /// <summary>
         /// Prepares config directory and files for current modlist
         /// </summary>
         /// <returns>path to modlistConfig</returns>
-        private Result GetOrCreateModlistConfigDir(string serverConfigDir, string modlistName) {
-            // Get modlist config directory based on serverConfig
-            var modlistConfigDir = Path.Join(serverConfigDir, "modlistConfigs", modlistName);
-
+        private Result GetOrCreateModlistConfigDir() {
             // Check for directory if present
-            if (!Directory.Exists(modlistConfigDir)) {
-                Directory.CreateDirectory(modlistConfigDir);
+            if (!Directory.Exists(DirectoryPath)) {
+                Directory.CreateDirectory(DirectoryPath);
             }
 
-            // Prepare modlist specific config.json if not exists
-            if (!File.Exists(Path.Join(modlistConfigDir, "config.json"))) {
-                // Set hostName according to pattern
-                var sampleServer = new Dictionary<string, string>();
-                sampleServer.Add("hostName", $"ArmaForces {modlistName} edition");
-                var sampleJSON = new Dictionary<string, Dictionary<string, string>>();
-                sampleJSON.Add("server", sampleServer);
-                // Write to file
-                using (StreamWriter file = File.CreateText(Path.Join(modlistConfigDir, "config.json"))) {
-                    var serializerOptions = new JsonSerializerOptions();
-                    serializerOptions.WriteIndented = true;
-                    var serializedJson = JsonSerializer.Serialize(sampleJSON, serializerOptions);
-                    file.Write(serializedJson);
-                }
-            }
+            return File.Exists(ConfigJson)
+                ? Result.Success()
+                : Result.Failure("No config.json found.");
+        }
 
+        private Result CreateConfigJson() {
+            // Set hostName according to pattern
+            var sampleServer = new Dictionary<string, string>();
+            sampleServer.Add("hostName", $"ArmaForces {ModlistName} edition");
+            var sampleJSON = new Dictionary<string, Dictionary<string, string>>();
+            sampleJSON.Add("server", sampleServer);
+            // Write to file
+            using (StreamWriter file = File.CreateText(ConfigJson))
+            {
+                var serializerOptions = new JsonSerializerOptions();
+                serializerOptions.WriteIndented = true;
+                var serializedJson = JsonSerializer.Serialize(sampleJSON, serializerOptions);
+                file.Write(serializedJson);
+            }
             return Result.Success();
         }
 
         /// <summary>
         /// Prepares modlist cfg files for server to load.
         /// </summary>
-        private Result PrepareModlistConfig(string modlistConfigDir, string modlistName) {
+        private Result PrepareModlistConfig() {
             // Apply modlist config on top of default config
-            var serverConfigDir = Path.GetFullPath(Path.Join("..", ".."), modlistConfigDir);
             var modlistConfig = new ConfigurationBuilder()
-                .AddJsonFile(Path.Join(serverConfigDir, "common.json"))
-                .AddJsonFile(Path.Join(modlistConfigDir, "config.json"))
+                .AddJsonFile(_serverConfig.ConfigJson)
+                .AddJsonFile(ConfigJson)
                 .Build();
 
             // Process configuration files for modlist
             var configs = new List<string> {"server", "basic"};
             foreach (var config in configs) {
-                Console.WriteLine($"Loading {config}.cfg for {modlistName} modlist.");
-                var cfgFile = ServerConfig.FillCfg(File.ReadAllText($"{serverConfigDir}\\{config}.cfg"),
+                Console.WriteLine($"Loading {config}.cfg for {ModlistName} modlist.");
+                var cfgFile = ServerConfig.FillCfg(
+                    File.ReadAllText($"{_serverConfig.DirectoryPath}\\{config}.cfg"),
                     modlistConfig.GetSection(config));
-                File.WriteAllText(Path.Join(modlistConfigDir, $"{config}.cfg"), cfgFile);
-                Console.WriteLine($"{config}.cfg successfully exported to {modlistConfigDir}");
+                File.WriteAllText(Path.Join(DirectoryPath, $"{config}.cfg"), cfgFile);
+                Console.WriteLine($"{config}.cfg successfully exported to {DirectoryPath}");
             }
 
             return Result.Success();

--- a/Arma.Server/Config/RegistryReader.cs
+++ b/Arma.Server/Config/RegistryReader.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Win32;
+
+namespace Arma.Server.Config {
+    public class RegistryReader : IRegistryReader {
+        public object GetValueFromLocalMachine(string subKey, string value)
+            => Registry.LocalMachine
+                .OpenSubKey(subKey)
+                ?.GetValue(value);
+    }
+}

--- a/Arma.Server/Config/ServerConfig.cs
+++ b/Arma.Server/Config/ServerConfig.cs
@@ -20,25 +20,27 @@ namespace Arma.Server.Config {
         /// <param name="settings">Server Settings Object</param>
         public ServerConfig(ISettings settings) {
             _settings = settings;
-            LoadConfig();
         }
-
-        private string CreateServerConfigDirPath()
-            =>  Path.Join(_settings.ServerDirectory, _settings.ServerConfigDirectoryName);
 
         /// <summary>
         /// Handles preparation of all config files.
         /// </summary>
         /// <returns></returns>
-        private Result LoadConfig() {
+        public Result LoadConfig() {
             Console.WriteLine("Loading ServerConfig.");
-            DirectoryPath = CreateServerConfigDirPath();
+            
+            return SetProperties()
+                .Bind(GetOrCreateServerConfigDir)
+                .Tap(() => Console.WriteLine("ServerConfig loaded."))
+                .OnFailure(e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
+        }
+
+        private Result SetProperties() {
+            DirectoryPath = Path.Join(_settings.ServerDirectory, _settings.ServerConfigDirectoryName);
             ConfigJson = Path.Join(DirectoryPath, "common.json");
             BasicCfg = Path.Join(DirectoryPath, "basic.cfg");
             ServerCfg = Path.Join(DirectoryPath, "server.cfg");
-            return GetOrCreateServerConfigDir()
-                .Tap(() => Console.WriteLine("ServerConfig loaded."))
-                .OnFailure(e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
+            return Result.Success();
         }
 
         /// <summary>

--- a/Arma.Server/Config/ServerConfig.cs
+++ b/Arma.Server/Config/ServerConfig.cs
@@ -7,8 +7,12 @@ using Microsoft.Extensions.Configuration;
 
 namespace Arma.Server.Config {
     public class ServerConfig : IConfig {
+        public string BasicCfg { get; protected set; }
+        public string ConfigJson { get; protected set; }
+        public string DirectoryPath { get; protected set; }
+        public string ServerCfg { get; protected set; }
+
         private readonly ISettings _settings;
-        private readonly string _serverConfigDirPath;
 
         /// <summary>
         /// Class prepares server configuration for given modlist
@@ -16,26 +20,22 @@ namespace Arma.Server.Config {
         /// <param name="settings">Server Settings Object</param>
         public ServerConfig(ISettings settings) {
             _settings = settings;
-
-            _serverConfigDirPath = CreateServerConfigDirPath();
+            LoadConfig();
         }
 
-        public string GetConfigDir() {
-            return _serverConfigDirPath;
-        }
-
-        private string CreateServerConfigDirPath() {
-            var serverPath = _settings.GetServerPath();
-            var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
-            return Path.Join(serverPath, serverConfigDirName);
-        }
+        private string CreateServerConfigDirPath()
+            =>  Path.Join(_settings.ServerDirectory, _settings.ServerConfigDirectoryName);
 
         /// <summary>
         /// Handles preparation of all config files.
         /// </summary>
         /// <returns></returns>
-        public Result LoadConfig() {
+        private Result LoadConfig() {
             Console.WriteLine("Loading ServerConfig.");
+            DirectoryPath = CreateServerConfigDirPath();
+            ConfigJson = Path.Join(DirectoryPath, "common.json");
+            BasicCfg = Path.Join(DirectoryPath, "basic.cfg");
+            ServerCfg = Path.Join(DirectoryPath, "server.cfg");
             return GetOrCreateServerConfigDir()
                 .Tap(() => Console.WriteLine("ServerConfig loaded."))
                 .OnFailure(e => Console.WriteLine("ServerConfig could not be loaded with {e}.", e));
@@ -46,18 +46,15 @@ namespace Arma.Server.Config {
         /// </summary>
         /// <returns>path to serverConfig</returns>
         private Result GetOrCreateServerConfigDir() {
-            var serverPath = _settings.GetServerPath();
-            var serverConfigDirName = _settings.GetSettingsValue("serverConfigDirName").ToString();
-            var serverConfigDir = Path.Join(serverPath, serverConfigDirName);
-            if (!Directory.Exists(serverConfigDir)) {
-                Console.WriteLine($"Config directory {serverConfigDirName} does not exists, creating.");
-                Directory.CreateDirectory(serverConfigDir);
+            if (!Directory.Exists(DirectoryPath)) {
+                Console.WriteLine($"Config directory {_settings.ServerConfigDirectoryName} does not exists, creating.");
+                Directory.CreateDirectory(DirectoryPath);
             }
 
             // Prepare files
             var filesList = new List<string>() {"basic.cfg", "server.cfg", "common.Arma3Profile", "common.json"};
             foreach (var fileName in filesList) {
-                var destFileName = Path.Join(serverConfigDir, fileName);
+                var destFileName = Path.Join(DirectoryPath, fileName);
                 if (File.Exists(destFileName)) continue;
                 Console.WriteLine($"{fileName} not found, copying.");
                 File.Copy(Path.Join(Directory.GetCurrentDirectory(), $"example_{fileName}"), destFileName);

--- a/Arma.Server/Config/ServerConfig.cs
+++ b/Arma.Server/Config/ServerConfig.cs
@@ -36,7 +36,7 @@ namespace Arma.Server.Config {
         }
 
         private Result SetProperties() {
-            DirectoryPath = Path.Join(_settings.ServerDirectory, _settings.ServerConfigDirectoryName);
+            DirectoryPath = _settings.ServerConfigDirectory;
             ConfigJson = Path.Join(DirectoryPath, "common.json");
             BasicCfg = Path.Join(DirectoryPath, "basic.cfg");
             ServerCfg = Path.Join(DirectoryPath, "server.cfg");
@@ -49,7 +49,7 @@ namespace Arma.Server.Config {
         /// <returns>path to serverConfig</returns>
         private Result GetOrCreateServerConfigDir() {
             if (!Directory.Exists(DirectoryPath)) {
-                Console.WriteLine($"Config directory {_settings.ServerConfigDirectoryName} does not exists, creating.");
+                Console.WriteLine($"Config directory {_settings.ServerConfigDirectory} does not exists, creating.");
                 Directory.CreateDirectory(DirectoryPath);
             }
 

--- a/Arma.Server/Config/Settings.cs
+++ b/Arma.Server/Config/Settings.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Win32;
@@ -11,43 +12,34 @@ namespace Arma.Server.Config {
         public string ServerConfigDirectory { get; protected set; }
         public string ServerDirectory { get; protected set; }
         public string ServerExecutable { get; protected set; }
-        public string ServerExecutableName { get; protected set; } = "arma3server_64.exe";
+        public string ServerExecutableName { get; protected set; } = "arma3server_x64.exe";
 
-        private static IConfigurationRoot _config;
+        private readonly IConfigurationRoot _config;
+        private IFileSystem _fileSystem;
+        private IRegistryReader _registryReader;
+
+        public Settings(IConfigurationRoot config = null,
+            IFileSystem fileSystem = null,
+            IRegistryReader registryReader = null) {
+            _fileSystem = fileSystem ?? new FileSystem();
+            _config = config ?? LoadConfigFile();
+            _registryReader = registryReader ?? new RegistryReader();
+        }
 
         public Result LoadSettings() {
             Console.WriteLine("Loading Manager Settings.");
-            return LoadConfigFile()
-                .Bind(GetServerPath)
-                .Tap((() => ServerExecutable = Path.Join(ServerDirectory, ServerExecutableName)))
-                .Tap(ObtainModsDirectory);
+            return GetServerPath()
+                .Tap(GetServerExecutable)
+                .Tap(ObtainModsDirectory)
+                .Tap(ObtainServerConfigDirectory);
         }
 
-        private Result LoadConfigFile()
-        {
-            _config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
+        private IConfigurationRoot LoadConfigFile()
+            => new ConfigurationBuilder()
+                .SetBasePath(_fileSystem.Directory.GetCurrentDirectory())
                 .AddJsonFile("settings.json")
                 .AddEnvironmentVariables()
                 .Build();
-            return Result.Success();
-        }
-
-        private Result GetServerPath() {
-            string serverPath = null;
-            var serverPathLoaded = GetServerPathFromConfig()
-                .Tap(x => serverPath = x)
-                .OnFailure(x => GetServerPathFromRegistry())
-                .Tap(x => serverPath = x)
-                .OnFailure(e => throw new ServerNotFoundException(e));
-            if (serverPathLoaded.IsFaulted)
-            {
-                throw serverPathLoaded.Exception.GetBaseException();
-            }
-
-            ServerDirectory = serverPath;
-            return Result.Success();
-        }
 
         private void ObtainServerConfigDirectory()
             => ServerConfigDirectory = _config["serverConfigDirectory"] ?? Path.Join(ServerDirectory, "serverConfig");
@@ -55,21 +47,38 @@ namespace Arma.Server.Config {
         private void ObtainModsDirectory()
             => ModsDirectory = _config["modsDirectory"] ?? Path.Join(ServerDirectory, "mods");
 
-        private Result<string> GetServerPathFromConfig() {
-            var serverPath = _config["serverDirectory"];
-            return Directory.Exists(serverPath)
-                ? Result.Success(serverPath)
-                : Result.Failure<string>("Server path could not be loaded from config.");
+        private Result GetServerPath() {
+            string serverPath = GetServerPathFromConfig() ?? GetServerPathFromRegistry();
+            ServerDirectory = serverPath ?? throw new ServerNotFoundException("Could not find server directory.");
+            return Result.Success();
         }
 
-        private Result<string> GetServerPathFromRegistry() {
-            var serverPath = Registry.LocalMachine
-                .OpenSubKey("SOFTWARE\\WOW6432Node\\bohemia interactive\\arma 3")
-                ?.GetValue("main")
-                .ToString();
-            return Directory.Exists(serverPath)
-                ? Result.Success(serverPath)
-                : Result.Failure<string>("Server path could not be loaded from registry.");
+        private string GetServerPathFromConfig() {
+            var serverPath = _config["serverDirectory"];
+            return _fileSystem.Directory.Exists(serverPath)
+                ? serverPath
+                : null;
+        }
+
+        private string GetServerPathFromRegistry() {
+            try {
+                var serverPath = _registryReader
+                    .GetValueFromLocalMachine(@"SOFTWARE\WOW6432Node\bohemia interactive\arma 3", "main")
+                    .ToString();
+                return _fileSystem.Directory.Exists(serverPath)
+                    ? serverPath
+                    : null;
+            } catch (NullReferenceException) {
+                return null;
+            }
+        }
+
+        private void GetServerExecutable() {
+            string serverExecutableName = _config["serverExecutableName"];
+            string serverExecutablePath = Path.Join(ServerDirectory, serverExecutableName);
+            ServerExecutable = _fileSystem.File.Exists(serverExecutablePath)
+                ? serverExecutablePath
+                : Path.Join(ServerDirectory, "arma3server_x64.exe");
         }
     }
 }

--- a/Arma.Server/Config/Settings.cs
+++ b/Arma.Server/Config/Settings.cs
@@ -8,7 +8,7 @@ namespace Arma.Server.Config {
     public class Settings : ISettings {
         public string ModlistConfigDirectoryName { get; protected set; } = "modlistConfig";
         public string ModsDirectory { get; protected set; }
-        public string ServerConfigDirectoryName { get; protected set; } = "serverConfig";
+        public string ServerConfigDirectory { get; protected set; }
         public string ServerDirectory { get; protected set; }
         public string ServerExecutable { get; protected set; }
         public string ServerExecutableName { get; protected set; } = "arma3server_64.exe";
@@ -49,11 +49,14 @@ namespace Arma.Server.Config {
             return Result.Success();
         }
 
+        private void ObtainServerConfigDirectory()
+            => ServerConfigDirectory = _config["serverConfigDirectory"] ?? Path.Join(ServerDirectory, "serverConfig");
+
         private void ObtainModsDirectory()
             => ModsDirectory = _config["modsDirectory"] ?? Path.Join(ServerDirectory, "mods");
 
         private Result<string> GetServerPathFromConfig() {
-            var serverPath = _config["serverPath"];
+            var serverPath = _config["serverDirectory"];
             return Directory.Exists(serverPath)
                 ? Result.Success(serverPath)
                 : Result.Failure<string>("Server path could not be loaded from config.");

--- a/Arma.Server/Config/Settings.cs
+++ b/Arma.Server/Config/Settings.cs
@@ -6,9 +6,14 @@ using Microsoft.Win32;
 
 namespace Arma.Server.Config {
     public class Settings : ISettings {
+        public string ModlistConfigDirectoryName { get; protected set; } = "modlistConfig";
+        public string ModsDirectory { get; protected set; }
+        public string ServerConfigDirectoryName { get; protected set; } = "serverConfig";
+        public string ServerDirectory { get; protected set; }
+        public string ServerExecutable { get; protected set; }
+        public string ServerExecutableName { get; protected set; } = "arma3server_64.exe";
+
         private static IConfigurationRoot _config;
-        private readonly string _executable = "arma3server_x64.exe";
-        private readonly string _serverPath;
 
         public Settings() {
             Console.WriteLine("Loading Manager Settings.");
@@ -23,23 +28,7 @@ namespace Arma.Server.Config {
                 throw serverPathLoaded.Exception.GetBaseException();
             }
 
-            _serverPath = serverPath;
-        }
-
-        public object GetSettingsValue(string key) {
-            try {
-                return _config[key];
-            } catch (NullReferenceException) {
-                return null;
-            }
-        }
-
-        public string GetServerPath() {
-            return _serverPath;
-        }
-
-        public string GetServerExePath() {
-            return _serverPath != null ? $"{_serverPath}\\{_executable}" : null;
+            ServerDirectory = serverPath;
         }
 
         private IConfigurationRoot LoadConfigFile() {

--- a/Arma.Server/Config/Settings.cs
+++ b/Arma.Server/Config/Settings.cs
@@ -18,7 +18,19 @@ namespace Arma.Server.Config {
         public Result LoadSettings() {
             Console.WriteLine("Loading Manager Settings.");
             return LoadConfigFile()
-                .Bind(GetServerPath);
+                .Bind(GetServerPath)
+                .Tap((() => ServerExecutable = Path.Join(ServerDirectory, ServerExecutableName)))
+                .Tap(ObtainModsDirectory);
+        }
+
+        private Result LoadConfigFile()
+        {
+            _config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("settings.json")
+                .AddEnvironmentVariables()
+                .Build();
+            return Result.Success();
         }
 
         private Result GetServerPath() {
@@ -37,14 +49,8 @@ namespace Arma.Server.Config {
             return Result.Success();
         }
 
-        private Result LoadConfigFile() {
-            _config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("settings.json")
-                .AddEnvironmentVariables()
-                .Build();
-            return Result.Success();
-        }
+        private void ObtainModsDirectory()
+            => ModsDirectory = _config["modsDirectory"] ?? Path.Join(ServerDirectory, "mods");
 
         private Result<string> GetServerPathFromConfig() {
             var serverPath = _config["serverPath"];

--- a/Arma.Server/Mod/Mod.cs
+++ b/Arma.Server/Mod/Mod.cs
@@ -3,28 +3,20 @@ using Newtonsoft.Json;
 
 namespace Arma.Server.Mod {
     public class Mod : IMod {
-        [JsonProperty]
         public string Id { get; set; }
 
-        [JsonProperty]
         public string Name { get; set; }
 
-        [JsonProperty]
         public DateTime CreatedAt { get; set; }
 
-        [JsonProperty]
         public DateTime? LastUpdatedAt { get; set; }
 
-        [JsonProperty]
         public ModSource Source { get; set; }
 
-        [JsonProperty]
         public ModType Type { get; set; }
 
-        [JsonProperty]
         public int ItemId { get; set; }
 
-        [JsonProperty]
         public string Directory { get; set; }
     }
 }

--- a/Arma.Server/Modlist/Modlist.cs
+++ b/Arma.Server/Modlist/Modlist.cs
@@ -5,19 +5,14 @@ using Newtonsoft.Json;
 
 namespace Arma.Server.Modlist {
     public class Modlist : IModlist {
-        [JsonProperty]
         public string Id { get; set; }
 
-        [JsonProperty]
         public string Name { get; set; }
 
-        [JsonProperty]
         public DateTime CreatedAt { get; set; }
 
-        [JsonProperty]
         public DateTime? LastUpdatedAt { get; set; }
 
-        [JsonProperty]
         public List<Mod.Mod> Mods { get; set; }
     }
 }

--- a/Arma.Server/Server.cs
+++ b/Arma.Server/Server.cs
@@ -6,9 +6,9 @@ namespace Arma.Server {
     public class Server {
         private ISettings _settings;
         private Process _serverProcess;
-        private ModlistConfig _modlistConfig;
+        private IModlistConfig _modlistConfig;
 
-        public Server(ISettings settings, ModlistConfig modlistConfig) {
+        public Server(ISettings settings, IModlistConfig modlistConfig) {
             _settings = settings;
             _modlistConfig = modlistConfig;
             Console.WriteLine("Initializing Server");
@@ -21,7 +21,7 @@ namespace Arma.Server {
         public bool Start() {
             Console.WriteLine("Starting Arma 3 Server");
             try {
-                _serverProcess = Process.Start(_settings.GetServerExePath(), GetServerStartupParams());
+                _serverProcess = Process.Start(_settings.ServerExecutable, GetServerStartupParams());
             } catch (NullReferenceException e) {
                 Console.WriteLine(e);
                 Console.WriteLine("Arma 3 Server could not be started. Path missing.");
@@ -47,9 +47,9 @@ namespace Arma.Server {
         private string GetServerStartupParams() {
             return String.Join(' ',
                 "-port=2302",
-                $"\"-config={_modlistConfig.GetServerCfgPath()}\"",
-                $"\"-cfg={_modlistConfig.GetBasicCfgPath()}\"",
-                $"-profiles=\"{_modlistConfig.GetServerProfileDir()}\"",
+                $"\"-config={_modlistConfig.ServerCfg}\"",
+                $"\"-cfg={_modlistConfig.BasicCfg}\"",
+                $"-profiles=\"{_modlistConfig.ServerProfileDirectory}\"",
                 "-name=server",
                 "-filePatching",
                 "-netlog",


### PR DESCRIPTION
When merged this PR will:
- [x] Create `IModlistConfig` interface inheriting from `IConfig`.
- [x] Refactor `Settings`/`ServerConfig`/`ModlistConfig` to use automatic properties.
- [x] Include automatic properties getters as main part of `ISettings`/`IConfig`/`IModlistConfig`.
- [x] Introduce getters for `basic.cfg`, `server.cfg`, `config.json` and more instead of creating paths every time.
- [x] Add ability to specify path to `serverConfig` directory.
- [x] Implement tests for all `Settings` settings.