### PR TITLE
Add missing ConfigReplacer tests and fix bug

### DIFF
--- a/Arma.Server.Test/Config/ConfigReplacerTests.cs
+++ b/Arma.Server.Test/Config/ConfigReplacerTests.cs
@@ -107,5 +107,32 @@ namespace Arma.Server.Test.Config {
             // Assert
             newCfgFile.Should().Contain(expectedMatch);
         }
+
+        [Fact]
+        public void ReplaceValue_Template_Match() {
+            // Arrange
+            var key = "template"; // It
+            var stringValue = "SomeMission.SomeMapCode";
+            var expectedMatch = $"\t\t{key} = {stringValue};";
+
+            // Act
+            var newCfgFile = ConfigReplacer.ReplaceValue(_cfgFile, key, stringValue);
+
+            // Assert
+            newCfgFile.Should().Contain(expectedMatch);
+        }
+
+        [Fact]
+        public void ReplaceValue_NoMatch_ConfigUnchanged() {
+            // Arrange
+            var key = "nonexistence"; // It doesn't exist
+            var stringValue = "";
+
+            // Act
+            var newCfgFile = ConfigReplacer.ReplaceValue(_cfgFile, key, stringValue);
+
+            // Assert
+            newCfgFile.Should().Be(_cfgFile);
+        }
     }
 }

--- a/Arma.Server.Test/test_server.cfg
+++ b/Arma.Server.Test/test_server.cfg
@@ -2,3 +2,13 @@
 hostName = ""; // Servername visible in the game browser. Default: hostName = ""
 admins[] = {""}; //e.g. {"1234","5678"} whitelisted client can use #login w/o password (since Arma 3 1.69+). Default: admins[] = {""}
 verifySignatures = 0; // Enables or disables the signature verification for addons. Default: verifySignatures = 3, disabled = 0
+
+class Missions
+{
+	class TestMission01
+	{
+		template = MP_Marksmen_01.Altis;
+		difficulty = "custom";
+		class Params {};
+	};
+};

--- a/Arma.Server/Config/ConfigReplacer.cs
+++ b/Arma.Server/Config/ConfigReplacer.cs
@@ -8,10 +8,11 @@ namespace Arma.Server.Config {
         /// </summary>
         public static string ReplaceValue(string config, string key, string value) {
             // Build regex expression with new line before key to prevent mid-line replacements
-            var expression = $"\n{key}";
-            if (key == "template") {
-                expression = $"\t\t{key}";
-            }
+            var whiteChars = key == "template"
+                ? "\t\t"
+                : "\n";
+
+            var expression = $"{whiteChars}{key}";
 
             // Check if $key contains '[]' eg. 'admins[]' as then it's value should be an array
             if (Regex.IsMatch(key, @"[[\]]")) {
@@ -37,8 +38,8 @@ namespace Arma.Server.Config {
             }
 
             var replacement = Regex.IsMatch(key, @"[[\]]")
-                ? $"\n{key} = {{{value}}};"
-                : $"\n{key} = {quote}{value}{quote};";
+                ? $"{whiteChars}{key} = {{{value}}};"
+                : $"{whiteChars}{key} = {quote}{value}{quote};";
             config = Regex.Replace(config, expression, replacement);
             Console.WriteLine($"\"{match.ToString().Substring(1)}\" => \"{replacement.Substring(1)}\"");
 


### PR DESCRIPTION
- [x] Cover 100% of `ConfigReplacer`
- [x] Fixed bug with incorrect handling when `template` key was used.

_Technically it was not a bug because everything worked, just formatting was broken._