### PR TITLE
Hangfire manager with advanced jobs scheduling

### DIFF
--- a/Arma.Server.Manager.Test/Extensions/DateTimeExtensionsTests.cs
+++ b/Arma.Server.Manager.Test/Extensions/DateTimeExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Arma.Server.Manager.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace Arma.Server.Manager.Test.Extensions
+{
+    public class DateTimeExtensionsTests
+    {
+        [Theory]
+        [ClassData(typeof(DateTimeTestData))]
+        public void IsCloseTo_ClassTestData(
+            DateTime dateTime,
+            DateTime referenceDateTime,
+            TimeSpan precision,
+            bool expectedResult)
+        {
+            var result = dateTime.IsCloseTo(referenceDateTime, precision);
+
+            result.Should().Be(expectedResult);
+        }
+    }
+
+    public class DateTimeTestData : IEnumerable<object[]>
+    {
+        private readonly TimeSpan _defaultPrecision = TimeSpan.FromMinutes(15);
+
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {DateTime.Now, DateTime.Now - TimeSpan.FromMinutes(10), _defaultPrecision, true};
+            yield return new object[] {DateTime.Now, DateTime.Now - TimeSpan.FromMinutes(20), _defaultPrecision, false};
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Arma.Server.Manager.Test/Features/Hangfire/HangfireManagerTests.cs
+++ b/Arma.Server.Manager.Test/Features/Hangfire/HangfireManagerTests.cs
@@ -1,0 +1,296 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Arma.Server.Manager.Features.Hangfire;
+using Arma.Server.Manager.Features.Hangfire.Helpers;
+using Arma.Server.Manager.Services;
+using Arma.Server.Manager.Test.Helpers.Dummy;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Hangfire.Common;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Moq;
+using Xunit;
+
+namespace Arma.Server.Manager.Test.Features.Hangfire
+{
+    public class HangfireManagerTests
+    {
+        private const string DummyClassFirstMethodName = "DoNothing";
+        private const string DummyClassSecondMethodName = "DoNothingAndNothing";
+
+        private readonly Mock<IHangfireBackgroundJobClient> _backgroundJobClientMock =
+            new Mock<IHangfireBackgroundJobClient>();
+
+        private readonly Mock<IHangfireJobStorage> _hangfireJobStorageMock = new Mock<IHangfireJobStorage>();
+
+        private readonly IHangfireManager _hangfireManager;
+        private readonly Mock<IMonitoringApi> _monitoringApiMock;
+
+        public HangfireManagerTests()
+        {
+            _hangfireManager = new HangfireManager(_backgroundJobClientMock.Object, _hangfireJobStorageMock.Object);
+
+            _monitoringApiMock = PrepareMonitoringApiMock();
+            _hangfireJobStorageMock.Setup(x => x.MonitoringApi).Returns(_monitoringApiMock.Object);
+        }
+
+        [Fact]
+        public void ScheduleJob_OtherJobExistsDateTimeNull_JobQueued()
+        {
+            var otherScheduledJob =
+                PrepareQueuedOrScheduledJob<ScheduledJobDto, DummyClass>(DummyClassSecondMethodName, DateTime.Now);
+            var scheduledJobList = PrepareJobList(new[] {otherScheduledJob});
+            AddScheduledJobs(scheduledJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(x => x.DoNothing(CancellationToken.None));
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Never);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Once);
+            }
+        }
+
+        [Fact]
+        public void ScheduleJob_JobScheduledInMinuteDateTimeNow_JobAlreadyQueued()
+        {
+            var dateTime = DateTime.Now;
+
+            var otherScheduledJob =
+                PrepareQueuedOrScheduledJob<ScheduledJobDto, DummyClass>(
+                    "DoNothing",
+                    DateTime.Now.AddMinutes(1));
+            var scheduledJobList = PrepareJobList(new[] {otherScheduledJob});
+            AddScheduledJobs(scheduledJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(
+                x => x.DoNothing(CancellationToken.None),
+                dateTime);
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Never);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        public void ScheduleJob_JobScheduledDateTimeNull_JobAlreadyScheduled()
+        {
+            var scheduledJob =
+                PrepareQueuedOrScheduledJob<ScheduledJobDto, DummyClass>(DummyClassFirstMethodName, DateTime.Now);
+            var scheduledJobList = PrepareJobList(new[] {scheduledJob});
+            AddScheduledJobs(scheduledJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(x => x.DoNothing(CancellationToken.None));
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Never);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        public void ScheduleJob_JobScheduledDateTimeNow_JobAlreadyScheduled()
+        {
+            var dateTime = DateTime.Now;
+
+            var scheduledJob =
+                PrepareQueuedOrScheduledJob<ScheduledJobDto, DummyClass>(DummyClassFirstMethodName, DateTime.Now);
+            var scheduledJobList = PrepareJobList(new[] {scheduledJob});
+            AddScheduledJobs(scheduledJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(
+                x => x.DoNothing(CancellationToken.None),
+                dateTime);
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Never);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        public void ScheduleJob_JobScheduledDateTimeInFuture_JobScheduled()
+        {
+            var dateTime = DateTime.Now.AddDays(1);
+
+            var scheduledJob =
+                PrepareQueuedOrScheduledJob<ScheduledJobDto, DummyClass>(DummyClassFirstMethodName, DateTime.Now);
+            var scheduledJobList = PrepareJobList(new[] {scheduledJob});
+            AddScheduledJobs(scheduledJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(
+                x => x.DoNothing(CancellationToken.None),
+                dateTime);
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Once);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        public void ScheduleJob_JobQueuedDateTimeNull_JobAlreadyQueued()
+        {
+            var queuedJob =
+                PrepareQueuedOrScheduledJob<EnqueuedJobDto, DummyClass>(DummyClassFirstMethodName, DateTime.Now);
+            var queuedJobList = PrepareJobList(new[] {queuedJob});
+            AddQueuedJobs(queuedJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(x => x.DoNothing(CancellationToken.None));
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Never);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        public void ScheduleJob_JobQueuedDateTimeNow_JobAlreadyQueued()
+        {
+            var dateTime = DateTime.Now;
+
+            var queuedJob =
+                PrepareQueuedOrScheduledJob<EnqueuedJobDto, DummyClass>(DummyClassFirstMethodName, DateTime.Now);
+            var queuedJobList = PrepareJobList(new[] {queuedJob});
+            AddQueuedJobs(queuedJobList);
+
+            var result = _hangfireManager.ScheduleJob<DummyClass>(
+                x => x.DoNothing(CancellationToken.None),
+                dateTime);
+
+            using (new AssertionScope())
+            {
+                result.IsSuccess.Should().BeTrue();
+                _backgroundJobClientMock.Verify(
+                    x => x.Schedule<DummyClass>(
+                        x => x.DoNothing(CancellationToken.None),
+                        It.IsAny<DateTimeOffset>()),
+                    Times.Never);
+                _backgroundJobClientMock.Verify(
+                    x => x.Enqueue<DummyClass>(x => x.DoNothing(CancellationToken.None)),
+                    Times.Never);
+            }
+        }
+
+        private static Mock<IMonitoringApi> PrepareMonitoringApiMock()
+        {
+            var monitoringApiMock = new Mock<IMonitoringApi>();
+
+            monitoringApiMock.Setup(x => x.ScheduledJobs(It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(new JobList<ScheduledJobDto>(new KeyValuePair<string, ScheduledJobDto>[0]));
+
+            monitoringApiMock.Setup(
+                    x => x.EnqueuedJobs(
+                        It.IsAny<string>(),
+                        It.IsAny<int>(),
+                        It.IsAny<int>()))
+                .Returns(new JobList<EnqueuedJobDto>(new KeyValuePair<string, EnqueuedJobDto>[0]));
+
+            return monitoringApiMock;
+        }
+
+        private void AddScheduledJobs(JobList<ScheduledJobDto> scheduledJobs)
+            => _monitoringApiMock.Setup(x => x.ScheduledJobs(It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(scheduledJobs);
+
+        private void AddQueuedJobs(JobList<EnqueuedJobDto> queuedJobs)
+            => _monitoringApiMock.Setup(
+                    x => x.EnqueuedJobs(
+                        It.IsAny<string>(),
+                        It.IsAny<int>(),
+                        It.IsAny<int>()))
+                .Returns(queuedJobs);
+
+        private static JobList<T> PrepareJobList<T>(IEnumerable<T> jobsList) where T : new()
+            => new JobList<T>(jobsList.Select(x => new KeyValuePair<string, T>("", x)));
+
+        private static TJob PrepareQueuedOrScheduledJob<TJob, TType>(string methodName, DateTime dateTime)
+            where TJob : class, new()
+            => PrepareQueuedOrScheduledJob<TJob>(PrepareJob<TType>(methodName), dateTime);
+
+        private static TJob PrepareQueuedOrScheduledJob<TJob>(Job job, DateTime dateTime) where TJob : class, new()
+        {
+            if (typeof(TJob) == typeof(ScheduledJobDto))
+                return PrepareScheduledJob(job, dateTime) as TJob;
+
+            if (typeof(TJob) == typeof(EnqueuedJobDto))
+                return PrepareQueuedJob(job, dateTime) as TJob;
+
+            return new TJob();
+        }
+
+        private static EnqueuedJobDto PrepareQueuedJob(Job job, in DateTime dateTime)
+            => new EnqueuedJobDto
+            {
+                EnqueuedAt = dateTime,
+                Job = job,
+                InEnqueuedState = true
+            };
+
+        private static ScheduledJobDto PrepareScheduledJob(Job job, DateTime dateTime)
+            => new ScheduledJobDto
+            {
+                EnqueueAt = dateTime,
+                ScheduledAt = dateTime,
+                Job = job,
+                InScheduledState = true
+            };
+
+        private static Job PrepareJob<T>(string methodName)
+            => new Job(
+                typeof(T),
+                typeof(T).GetMethod(methodName),
+                CancellationToken.None);
+    }
+}

--- a/Arma.Server.Manager.Test/Features/Hangfire/HangfireManagerTests.cs
+++ b/Arma.Server.Manager.Test/Features/Hangfire/HangfireManagerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using Arma.Server.Manager.Features.Hangfire;
 using Arma.Server.Manager.Features.Hangfire.Helpers;
-using Arma.Server.Manager.Services;
 using Arma.Server.Manager.Test.Helpers.Dummy;
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/Arma.Server.Manager.Test/Helpers/Dummy/DummyClass.cs
+++ b/Arma.Server.Manager.Test/Helpers/Dummy/DummyClass.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arma.Server.Manager.Features.Hangfire;
+
+namespace Arma.Server.Manager.Test.Helpers.Dummy
+{
+    /// <summary>
+    /// Class for <see cref="IHangfireManager"/> testing purposes.
+    /// </summary>
+    public class DummyClass
+    {
+        /// <summary>
+        /// Does nothing.
+        /// Needed for <see cref="IHangfireManager"/> tests.
+        /// </summary>
+        public async Task DoNothing(CancellationToken cancellationToken)
+        {
+        }
+
+        /// <summary>
+        /// Does nothing and even more nothing.
+        /// Needed for <see cref="IHangfireManager"/> tests.
+        /// </summary>
+        public async Task DoNothingAndNothing(CancellationToken cancellationToken)
+        {
+        }
+    }
+}

--- a/Arma.Server.Manager/Extensions/DateTimeExtensions.cs
+++ b/Arma.Server.Manager/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Arma.Server.Manager.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        ///     Checks whether given <paramref name="dateTime" /> is within <paramref name="precision" /> <see cref="TimeSpan" />
+        ///     from <paramref name="referenceDateTime" />.
+        /// </summary>
+        /// <param name="dateTime">Checked date time.</param>
+        /// <param name="referenceDateTime">Reference date time.</param>
+        /// <param name="precision">Time span from reference date time. Default is 1 hour.</param>
+        public static bool IsCloseTo(
+            this DateTime dateTime,
+            DateTime referenceDateTime,
+            TimeSpan? precision = null)
+        {
+            precision ??= TimeSpan.FromHours(1);
+            return referenceDateTime - precision < dateTime && referenceDateTime + precision > dateTime;
+        }
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/HangfireManager.cs
+++ b/Arma.Server.Manager/Features/Hangfire/HangfireManager.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using Arma.Server.Manager.Extensions;
+using Arma.Server.Manager.Features.Hangfire.Helpers;
+using CSharpFunctionalExtensions;
+using Hangfire.Common;
+using Hangfire.Storage.Monitoring;
+
+namespace Arma.Server.Manager.Features.Hangfire
+{
+    public class HangfireManager : IHangfireManager
+    {
+        private readonly IHangfireBackgroundJobClient _backgroundJobClient;
+
+        private readonly TimeSpan _defaultPrecision = TimeSpan.FromMinutes(15);
+        private readonly IHangfireJobStorage _hangfireJobStorage;
+
+        public HangfireManager(IHangfireBackgroundJobClient backgroundJobClient, IHangfireJobStorage hangfireJobStorage)
+        {
+            _backgroundJobClient = backgroundJobClient;
+            _hangfireJobStorage = hangfireJobStorage;
+        }
+
+        public Result ScheduleJob<T>(Expression<Func<T, Task>> func, DateTime? dateTime = null) where T : new()
+            => dateTime.HasValue
+                ? ScheduleAt(func, dateTime.Value)
+                : ScheduleImmediately(func);
+
+        private Result ScheduleAt<T>(Expression<Func<T, Task>> func, DateTime dateTime) where T : new()
+        {
+            var scheduledJobs = GetSimilarScheduledJobs(func)
+                .Where(x => x.EnqueueAt.IsCloseTo(dateTime, _defaultPrecision));
+
+            var queuedJobs = GetSimilarQueuedJobs(func);
+
+            if (scheduledJobs.Any() || queuedJobs.Any())
+                return Result.Success();
+
+            _backgroundJobClient.Schedule(func, dateTime);
+
+            return Result.Success();
+        }
+
+        private Result ScheduleImmediately<T>(Expression<Func<T, Task>> func) where T : new()
+        {
+            var scheduledJobs = GetSimilarScheduledJobs(func)
+                .Where(x => x.EnqueueAt.IsCloseTo(DateTime.Now, _defaultPrecision));
+
+            var queuedJobs = GetSimilarQueuedJobs(func);
+
+            if (scheduledJobs.Any() || queuedJobs.Any())
+                return Result.Success();
+
+            _backgroundJobClient.Enqueue(func);
+
+            return Result.Success();
+        }
+
+        private IEnumerable<ScheduledJobDto> GetSimilarScheduledJobs<T>(
+            Expression<Func<T, Task>> func,
+            int from = 0,
+            int count = 50)
+            => GetScheduledJobs(from, count)
+                .Where(x => JobMatchesMethod(x.Job, func));
+
+        private IEnumerable<ScheduledJobDto> GetScheduledJobs(int from = 0, int count = 50)
+            => _hangfireJobStorage.MonitoringApi
+                .ScheduledJobs(from, count)
+                .Select(x => x.Value);
+
+        private IEnumerable<EnqueuedJobDto> GetSimilarQueuedJobs<T>(
+            Expression<Func<T, Task>> func,
+            string queue = "default",
+            int from = 0,
+            int perPage = 50)
+            => GetQueuedJobs(
+                    queue,
+                    from,
+                    perPage)
+                .Where(x => JobMatchesMethod(x.Job, func));
+
+        private IEnumerable<EnqueuedJobDto> GetQueuedJobs(
+            string queue = "default",
+            int from = 0,
+            int perPage = 50)
+            => _hangfireJobStorage.MonitoringApi
+                .EnqueuedJobs(
+                    queue,
+                    from,
+                    perPage)
+                .Select(x => x.Value);
+
+        private static bool JobMatchesMethod<T>(Job job, Expression<Func<T, Task>> func)
+            => job.Type == typeof(T) && func.Body.ToString().Contains(job.Method.Name);
+
+        private static bool TypeHasMethod<T>(MethodInfo methodInfo)
+            => typeof(T)
+                .GetMethods()
+                .Any(x => x == methodInfo);
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireBackgroundJobClient.cs
+++ b/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireBackgroundJobClient.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Hangfire;
+
+namespace Arma.Server.Manager.Features.Hangfire.Helpers
+{
+    public class HangfireBackgroundJobClient : IHangfireBackgroundJobClient
+    {
+        private readonly IBackgroundJobClient _backgroundJobClient = new BackgroundJobClient();
+
+        public string Schedule<T>(Expression<Func<T, Task>> methodCall, DateTimeOffset dateTimeOffset)
+            => _backgroundJobClient.Schedule(methodCall, dateTimeOffset);
+
+        public string Enqueue<T>(Expression<Func<T, Task>> methodCall)
+            => _backgroundJobClient.Enqueue(methodCall);
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireJobStorage.cs
+++ b/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireJobStorage.cs
@@ -1,0 +1,14 @@
+﻿using Hangfire;
+using Hangfire.Storage;
+
+namespace Arma.Server.Manager.Features.Hangfire.Helpers {
+    public class HangfireJobStorage : IHangfireJobStorage {
+        private readonly JobStorage _jobStorage = JobStorage.Current;
+
+        public IMonitoringApi MonitoringApi { get; }
+
+        public HangfireJobStorage() {
+            MonitoringApi = _jobStorage.GetMonitoringApi();
+        }
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/Helpers/IHangfireBackgroundJobClient.cs
+++ b/Arma.Server.Manager/Features/Hangfire/Helpers/IHangfireBackgroundJobClient.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Arma.Server.Manager.Features.Hangfire.Helpers
+{
+    public interface IHangfireBackgroundJobClient
+    {
+        string Schedule<T>(Expression<Func<T, Task>> methodCall, DateTimeOffset dateTimeOffset);
+
+        string Enqueue<T>(Expression<Func<T, Task>> methodCall);
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/Helpers/IHangfireJobStorage.cs
+++ b/Arma.Server.Manager/Features/Hangfire/Helpers/IHangfireJobStorage.cs
@@ -1,0 +1,7 @@
+﻿using Hangfire.Storage;
+
+namespace Arma.Server.Manager.Features.Hangfire.Helpers {
+    public interface IHangfireJobStorage {
+        IMonitoringApi MonitoringApi { get; }
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/IHangfireManager.cs
+++ b/Arma.Server.Manager/Features/Hangfire/IHangfireManager.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+
+namespace Arma.Server.Manager.Features.Hangfire {
+    public interface IHangfireManager {
+        Result ScheduleJob<T>(Expression<Func<T, Task>> func, DateTime? dateTime = null) where T : new();
+    }
+}

--- a/Arma.Server.Manager/Features/Hangfire/IHangfireManager.cs
+++ b/Arma.Server.Manager/Features/Hangfire/IHangfireManager.cs
@@ -4,7 +4,18 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 
 namespace Arma.Server.Manager.Features.Hangfire {
+    /// <summary>
+    /// Allows advanced jobs scheduling.
+    /// </summary>
     public interface IHangfireManager {
+        /// <summary>
+        /// Schedule job expressed as <paramref name="func"/> for execution at <paramref name="dateTime"/>.
+        /// 
+        /// </summary>
+        /// <typeparam name="T">Class used in Job expression.</typeparam>
+        /// <param name="func">Expression to execute as job.</param>
+        /// <param name="dateTime">When job should be executed.</param>
+        /// <returns>Successful <see cref="Result"/> if job was correctly scheduled or was scheduled before around given <paramref name="dateTime"/>.</returns>
         Result ScheduleJob<T>(Expression<Func<T, Task>> func, DateTime? dateTime = null) where T : new();
     }
 }

--- a/Arma.Server.Manager/Program.cs
+++ b/Arma.Server.Manager/Program.cs
@@ -1,3 +1,5 @@
+using Arma.Server.Manager.Features.Hangfire;
+using Arma.Server.Manager.Features.Hangfire.Helpers;
 using Arma.Server.Manager.Services;
 using Hangfire;
 using Hangfire.LiteDB;
@@ -28,6 +30,10 @@ namespace Arma.Server.Manager
                     services.AddHangfireServer();
 
                     services.AddHostedService<ModsUpdateService>();
+
+                    services.AddSingleton<IHangfireBackgroundJobClient>();
+                    services.AddSingleton<IHangfireJobStorage>();
+                    services.AddSingleton<IHangfireManager>();
                 });
     }
 }

--- a/ArmaServerManager.sln.DotSettings
+++ b/ArmaServerManager.sln.DotSettings
@@ -4,4 +4,5 @@
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=04E3652C4C29A24399350EE3915AA9C7/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File04E3652C4C29A24399350EE3915AA9C7/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File04E3652C4C29A24399350EE3915AA9C7/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hangfire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modset/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
When merged this PR will:
- [x] Add Hangfire Manager for advanced jobs scheduling. Prevents scheduling the same job within 15 minutes timespan.
- [x] `bool DateTime.IsCloseTo(this DateTime, DateTime, TimeSpan)` extension method for checking if dateTime is withing given timespan from reference dateTime.
- [x] Add `Hangfire` to solution dictionary.