### PR TITLE
Rework mods downloader

### DIFF
--- a/Arma.Server.Manager.Test/Arma.Server.Manager.Test.csproj
+++ b/Arma.Server.Manager.Test/Arma.Server.Manager.Test.csproj
@@ -8,14 +8,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.13.0" />
+    <PackageReference Include="AutoFixture" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.7" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Arma.Server.Manager.Test/Clients/Steam/SteamClientTests.cs
+++ b/Arma.Server.Manager.Test/Clients/Steam/SteamClientTests.cs
@@ -21,7 +21,7 @@ namespace Arma.Server.Manager.Test.Clients.Steam {
             var cancellationTokenSource = new CancellationTokenSource();
 
             cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(1));
-            Func<Task> action = async () => await steamClient.Connect(cancellationTokenSource.Token);
+            Func<Task> action = async () => await steamClient.EnsureConnected(cancellationTokenSource.Token);
 
             action.Should().Throw<OperationCanceledException>();
         }
@@ -34,7 +34,7 @@ namespace Arma.Server.Manager.Test.Clients.Steam {
             settingsMock.Setup(x => x.ModsDirectory).Returns("");
             var steamClient = new SteamClient(settingsMock.Object);
 
-            Func<Task> action = async () => await steamClient.Connect(CancellationToken.None);
+            Func<Task> action = async () => await steamClient.EnsureConnected(CancellationToken.None);
 
             action.Should().Throw<InvalidCredentialException>("Invalid Steam Credentials");
         }

--- a/Arma.Server.Manager.Test/Clients/Steam/SteamClientTests.cs
+++ b/Arma.Server.Manager.Test/Clients/Steam/SteamClientTests.cs
@@ -5,14 +5,16 @@ using System.Threading.Tasks;
 using Arma.Server.Config;
 using Arma.Server.Manager.Clients.Steam;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using Moq;
 using Xunit;
 
-namespace Arma.Server.Manager.Test.Clients.Steam {
-    public class SteamClientTests {
+namespace Arma.Server.Manager.Test.Clients.Steam
+{
+    public class SteamClientTests
+    {
         [Fact]
-        public void Connect_CancellationRequested_TaskCancelled() {
+        public void Connect_CancellationRequested_TaskCancelled()
+        {
             var settingsMock = new Mock<ISettings>();
             settingsMock.Setup(x => x.SteamUser).Returns("");
             settingsMock.Setup(x => x.SteamPassword).Returns("");
@@ -25,9 +27,10 @@ namespace Arma.Server.Manager.Test.Clients.Steam {
 
             action.Should().Throw<OperationCanceledException>();
         }
-        
+
         [Fact]
-        public void Connect_InvalidCredentials_ThrowsInvalidCredentialsException() {
+        public void Connect_InvalidCredentials_ThrowsInvalidCredentialsException()
+        {
             var settingsMock = new Mock<ISettings>();
             settingsMock.Setup(x => x.SteamUser).Returns("");
             settingsMock.Setup(x => x.SteamPassword).Returns("");

--- a/Arma.Server.Manager.Test/Helpers/Dummy/DummyClass.cs
+++ b/Arma.Server.Manager.Test/Helpers/Dummy/DummyClass.cs
@@ -2,6 +2,9 @@
 using System.Threading.Tasks;
 using Arma.Server.Manager.Features.Hangfire;
 
+// Disable call not awaited
+#pragma warning disable 1998
+
 namespace Arma.Server.Manager.Test.Helpers.Dummy
 {
     /// <summary>

--- a/Arma.Server.Manager.Test/Mods/ModsManagerTests.cs
+++ b/Arma.Server.Manager.Test/Mods/ModsManagerTests.cs
@@ -22,7 +22,7 @@ namespace Arma.Server.Manager.Test.Mods {
     public class ModsManagerTests {
         private readonly Fixture _fixture = new Fixture();
         private readonly Mock<IModsCache> _modsCacheMock = new Mock<IModsCache>();
-        private readonly Mock<ISteamClient> _steamClientMock = new Mock<ISteamClient>();
+        private readonly Mock<IModsDownloader> _downloaderMock = new Mock<IModsDownloader>();
         private readonly ModsManager _modsManager;
         private readonly IModset _modset;
 
@@ -31,7 +31,7 @@ namespace Arma.Server.Manager.Test.Mods {
                 Mods = new HashSet<IMod> { FixtureCreateMod() }
             };
 
-            _modsManager = new ModsManager(_steamClientMock.Object, _modsCacheMock.Object);
+            _modsManager = new ModsManager(_downloaderMock.Object, _modsCacheMock.Object);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace Arma.Server.Manager.Test.Mods {
 
             _modsManager.PrepareModset(_modset);
 
-            _steamClientMock.Verify(x => x.Download(modsEnumerable, It.IsAny<CancellationToken>()));
+            _downloaderMock.Verify(x => x.DownloadMods(modsEnumerable, It.IsAny<CancellationToken>()));
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Arma.Server.Manager.Test.Mods {
 
             _modsManager.PrepareModset(_modset);
 
-            _steamClientMock.Verify(x => x.Download(
+            _downloaderMock.Verify(x => x.DownloadMods(
                 It.IsAny<IEnumerable<int>>(),
                 It.IsAny<CancellationToken>()),
                 Times.Never);
@@ -69,8 +69,8 @@ namespace Arma.Server.Manager.Test.Mods {
             settingsMock.Setup(x => x.SteamPassword).Returns("");
             settingsMock.Setup(x => x.ModsDirectory).Returns(workingDirectory);
             var modsCache = new ModsCache(settingsMock.Object, fileSystemMock);
-            var steamClient = new SteamClient(settingsMock.Object);
-            var modsManager = new ModsManager(steamClient, modsCache);
+            var downloader = new ModsDownloader(settingsMock.Object);
+            var modsManager = new ModsManager(downloader, modsCache);
             var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(1));
 

--- a/Arma.Server.Manager.Test/Mods/ModsManagerTests.cs
+++ b/Arma.Server.Manager.Test/Mods/ModsManagerTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
-using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using Arma.Server.Config;
@@ -15,7 +14,6 @@ using Arma.Server.Manager.Clients.Steam;
 using Arma.Server.Modset;
 using FluentAssertions.Execution;
 using Moq;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Arma.Server.Manager.Test.Mods {

--- a/Arma.Server.Manager.Web/Arma.Server.Manager.Web.csproj
+++ b/Arma.Server.Manager.Web/Arma.Server.Manager.Web.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.14" />
-    <PackageReference Include="Hangfire.LiteDB" Version="0.3.1" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.14" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.17" />
+    <PackageReference Include="Hangfire.LiteDB" Version="0.4.0" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Arma.Server.Manager/Arma.Server.Manager.csproj
+++ b/Arma.Server.Manager/Arma.Server.Manager.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="BytexDigital.Steam" Version="0.7.40-beta" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.14" />
     <PackageReference Include="Hangfire.LiteDB" Version="0.3.1" />
+    <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
   </ItemGroup>
 

--- a/Arma.Server.Manager/Arma.Server.Manager.csproj
+++ b/Arma.Server.Manager/Arma.Server.Manager.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="BytexDigital.Steam" Version="0.7.40-beta" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.14" />
-    <PackageReference Include="Hangfire.LiteDB" Version="0.3.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.17" />
+    <PackageReference Include="Hangfire.LiteDB" Version="0.4.0" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Arma.Server.Manager/Clients/Steam/IModsDownloader.cs
+++ b/Arma.Server.Manager/Clients/Steam/IModsDownloader.cs
@@ -2,32 +2,34 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Arma.Server.Manager.Clients.Steam {
+namespace Arma.Server.Manager.Clients.Steam
+{
     /// <summary>
-    /// Handles downloading/updating mods and arma server.
+    ///     Handles downloading/updating mods and arma server.
     /// </summary>
-    public interface IModsDownloader {
+    public interface IModsDownloader
+    {
         /// <summary>
-        /// Downloads arma server.
+        ///     Downloads arma server.
         /// </summary>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> for safe download abort.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
+        /// <param name="cancellationToken"><see cref="CancellationToken" /> for safe download abort.</param>
+        /// <returns>Awaitable <see cref="Task" /></returns>
         Task DownloadArmaServer(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Downloads mod with given <paramref name="itemId"/>.
+        ///     Downloads mod with given <paramref name="itemId" />.
         /// </summary>
         /// <param name="itemId">ID of item to download</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> for safe download abort.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
+        /// <param name="cancellationToken"><see cref="CancellationToken" /> for safe download abort.</param>
+        /// <returns>Awaitable <see cref="Task" /></returns>
         Task DownloadMod(int itemId, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Downloads mods one by one from list of <paramref name="itemsIds"/>.
+        ///     Downloads mods one by one from list of <paramref name="itemsIds" />.
         /// </summary>
         /// <param name="itemsIds">IDs of items to download</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> for safe download abort.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
+        /// <param name="cancellationToken"><see cref="CancellationToken" /> for safe download abort.</param>
+        /// <returns>Awaitable <see cref="Task" /></returns>
         Task DownloadMods(IEnumerable<int> itemsIds, CancellationToken cancellationToken);
     }
 }

--- a/Arma.Server.Manager/Clients/Steam/IModsDownloader.cs
+++ b/Arma.Server.Manager/Clients/Steam/IModsDownloader.cs
@@ -6,7 +6,7 @@ namespace Arma.Server.Manager.Clients.Steam {
     /// <summary>
     /// Handles downloading/updating mods and arma server.
     /// </summary>
-    public interface IDownloader {
+    public interface IModsDownloader {
         /// <summary>
         /// Downloads arma server.
         /// </summary>

--- a/Arma.Server.Manager/Clients/Steam/ISteamClient.cs
+++ b/Arma.Server.Manager/Clients/Steam/ISteamClient.cs
@@ -1,38 +1,24 @@
-﻿using System.Collections.Generic;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+using BytexDigital.Steam.ContentDelivery;
 
 namespace Arma.Server.Manager.Clients.Steam {
     /// <summary>
     /// Handles connection to Steam Servers and downloading of mods.
     /// </summary>
     public interface ISteamClient {
+        SteamContentClient ContentClient { get; }
+
         /// <summary>
         /// Connects to Steam Servers.
         /// </summary>
         /// /// <param name="cancellationToken"><see cref="CancellationToken"/> used for safe connection aborting.</param>
         /// <returns>Awaitable <see cref="Task"/></returns>
-        Task Connect(CancellationToken cancellationToken);
+        Task EnsureConnected(CancellationToken cancellationToken);
 
         /// <summary>
         /// Disconnects from Steam Servers.
         /// </summary>
         void Disconnect();
-
-        /// <summary>
-        /// Starts download of given <paramref name="itemId"/>.
-        /// </summary>
-        /// <param name="itemId">Item to download.</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> used for safe download cancellation.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
-        Task Download(int itemId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Starts download of given <paramref name="itemsIds"/>.
-        /// </summary>
-        /// <param name="itemsIds">List of items to download.</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> used for safe download cancellation.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
-        Task Download(IEnumerable<int> itemsIds, CancellationToken cancellationToken);
     }
 }

--- a/Arma.Server.Manager/Clients/Steam/ISteamClient.cs
+++ b/Arma.Server.Manager/Clients/Steam/ISteamClient.cs
@@ -2,22 +2,27 @@
 using System.Threading.Tasks;
 using BytexDigital.Steam.ContentDelivery;
 
-namespace Arma.Server.Manager.Clients.Steam {
+namespace Arma.Server.Manager.Clients.Steam
+{
     /// <summary>
-    /// Handles connection to Steam Servers and downloading of mods.
+    ///     Handles connection to Steam Servers and downloading of mods.
     /// </summary>
-    public interface ISteamClient {
+    public interface ISteamClient
+    {
+        /// <summary>
+        ///     Content client for downloading.
+        /// </summary>
         SteamContentClient ContentClient { get; }
 
         /// <summary>
-        /// Connects to Steam Servers.
+        ///     Ensures client is connected to Steam Servers.
         /// </summary>
-        /// /// <param name="cancellationToken"><see cref="CancellationToken"/> used for safe connection aborting.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
+        /// <param name="cancellationToken"><see cref="CancellationToken" /> used for safe connection aborting.</param>
+        /// <returns>Awaitable <see cref="Task" /></returns>
         Task EnsureConnected(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Disconnects from Steam Servers.
+        ///     Disconnects from Steam Servers.
         /// </summary>
         void Disconnect();
     }

--- a/Arma.Server.Manager/Clients/Steam/SteamClient.cs
+++ b/Arma.Server.Manager/Clients/Steam/SteamClient.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Arma.Server.Config;
 using BytexDigital.Steam.ContentDelivery;
 using BytexDigital.Steam.Core;
+using Microsoft.Extensions.DependencyInjection;
 using BytexSteamClient = BytexDigital.Steam.Core.SteamClient;
 
 namespace Arma.Server.Manager.Clients.Steam {
@@ -31,6 +32,11 @@ namespace Arma.Server.Manager.Clients.Steam {
             _bytexSteamClient = new BytexSteamClient(_steamCredentials);
             _contentClient = new SteamContentClient(_bytexSteamClient);
             Downloader = new Downloader(this, _contentClient, settings.ModsDirectory);
+        }
+
+        public static SteamClient CreateSteamClient(IServiceProvider serviceProvider)
+        {
+            return new SteamClient(serviceProvider.GetService<ISettings>());
         }
 
         /// <inheritdoc />
@@ -60,11 +66,11 @@ namespace Arma.Server.Manager.Clients.Steam {
         }
 
         /// <inheritdoc />
-        public async Task Download(int itemId, CancellationToken cancellationToken)
+        public async Task Download(int itemId, CancellationToken cancellationToken) 
             => await Downloader.DownloadMod(itemId, cancellationToken);
 
         /// <inheritdoc />
-        public async Task Download(IEnumerable<int> itemsIds, CancellationToken cancellationToken)
+        public async Task Download(IEnumerable<int> itemsIds, CancellationToken cancellationToken) 
             => await Downloader.DownloadMods(itemsIds, cancellationToken);
     }
 }

--- a/Arma.Server.Manager/Clients/Steam/SteamClient.cs
+++ b/Arma.Server.Manager/Clients/Steam/SteamClient.cs
@@ -8,57 +8,62 @@ using BytexDigital.Steam.Core;
 using Microsoft.Extensions.DependencyInjection;
 using BytexSteamClient = BytexDigital.Steam.Core.SteamClient;
 
-namespace Arma.Server.Manager.Clients.Steam {
+namespace Arma.Server.Manager.Clients.Steam
+{
     /// <inheritdoc />
-    public class SteamClient : ISteamClient {
-        private const int SteamAppId = 233780; // Arma 3 Server
-        private readonly SteamCredentials _steamCredentials;
-
+    public class SteamClient : ISteamClient
+    {
         private readonly BytexSteamClient _bytexSteamClient;
-        public SteamContentClient ContentClient { get; }
+        private readonly SteamCredentials _steamCredentials;
 
         /// <inheritdoc />
         /// <param name="settings">Settings containing steam user, password and mods directory.</param>
-        public SteamClient(ISettings settings) : this(settings.SteamUser, settings.SteamPassword, settings) { }
+        public SteamClient(ISettings settings) : this(settings.SteamUser, settings.SteamPassword)
+        {
+        }
 
         /// <inheritdoc cref="SteamClient" />
         /// <param name="user">Steam username.</param>
         /// <param name="password">Steam password.</param>
-        /// <param name="settings">Settings containing mods directory.</param>
-        public SteamClient(string user, string password, ISettings settings) {
+        public SteamClient(string user, string password)
+        {
             _steamCredentials = new SteamCredentials(user, password);
             _bytexSteamClient = new BytexSteamClient(_steamCredentials);
             ContentClient = new SteamContentClient(_bytexSteamClient);
         }
 
-        public static SteamClient CreateSteamClient(IServiceProvider serviceProvider)
-        {
-            return new SteamClient(serviceProvider.GetService<ISettings>());
-        }
+        public SteamContentClient ContentClient { get; }
 
         /// <inheritdoc />
-        /// <exception cref="OperationCanceledException">Thrown when <see cref="CancellationToken"/> is cancelled.</exception>
-        /// <exception cref="InvalidCredentialException">Thrown when Steam credentials are invalid and connection could not be established.</exception>
-        public async Task EnsureConnected(CancellationToken cancellationToken) {
+        /// <exception cref="OperationCanceledException">Thrown when <see cref="CancellationToken" /> is cancelled.</exception>
+        /// <exception cref="InvalidCredentialException">
+        ///     Thrown when Steam credentials are invalid and connection could not be
+        ///     established.
+        /// </exception>
+        public async Task EnsureConnected(CancellationToken cancellationToken)
+        {
             var connectCancellationTokenSource = new CancellationTokenSource();
             var connectTask = _bytexSteamClient.ConnectAsync(connectCancellationTokenSource.Token);
             var connectionTimeout = Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
             await Task.WhenAny(connectTask, connectionTimeout);
 
-            if (cancellationToken.IsCancellationRequested) {
+            if (cancellationToken.IsCancellationRequested)
+            {
                 connectCancellationTokenSource.Cancel();
                 throw new OperationCanceledException(cancellationToken);
             }
 
-            if (connectTask.Status == TaskStatus.WaitingForActivation) {
+            if (connectTask.Status == TaskStatus.WaitingForActivation)
+            {
                 connectCancellationTokenSource.Cancel();
                 throw new InvalidCredentialException("Invalid Steam Credentials");
             }
         }
 
         /// <inheritdoc />
-        public void Disconnect() {
-            _bytexSteamClient.Shutdown();
-        }
+        public void Disconnect() => _bytexSteamClient.Shutdown();
+
+        public static SteamClient CreateSteamClient(IServiceProvider serviceProvider)
+            => new SteamClient(serviceProvider.GetService<ISettings>());
     }
 }

--- a/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireBackgroundJobClient.cs
+++ b/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireBackgroundJobClient.cs
@@ -14,5 +14,8 @@ namespace Arma.Server.Manager.Features.Hangfire.Helpers
 
         public string Enqueue<T>(Expression<Func<T, Task>> methodCall)
             => _backgroundJobClient.Enqueue(methodCall);
+
+        public static HangfireBackgroundJobClient CreateHangfireBackgroundJobClient(IServiceProvider serviceProvider)
+            => new HangfireBackgroundJobClient();
     }
 }

--- a/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireJobStorage.cs
+++ b/Arma.Server.Manager/Features/Hangfire/Helpers/HangfireJobStorage.cs
@@ -1,14 +1,18 @@
-﻿using Hangfire;
+﻿using System;
+using Hangfire;
 using Hangfire.Storage;
 
-namespace Arma.Server.Manager.Features.Hangfire.Helpers {
-    public class HangfireJobStorage : IHangfireJobStorage {
+namespace Arma.Server.Manager.Features.Hangfire.Helpers
+{
+    public class HangfireJobStorage : IHangfireJobStorage
+    {
         private readonly JobStorage _jobStorage = JobStorage.Current;
+
+        public HangfireJobStorage() => MonitoringApi = _jobStorage.GetMonitoringApi();
 
         public IMonitoringApi MonitoringApi { get; }
 
-        public HangfireJobStorage() {
-            MonitoringApi = _jobStorage.GetMonitoringApi();
-        }
+        public static HangfireJobStorage CreateHangfireJobStorage(IServiceProvider serviceProvider)
+            => new HangfireJobStorage();
     }
 }

--- a/Arma.Server.Manager/Mods/IModsCache.cs
+++ b/Arma.Server.Manager/Mods/IModsCache.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Arma.Server.Mod;
 
 namespace Arma.Server.Manager.Mods {
@@ -19,6 +20,6 @@ namespace Arma.Server.Manager.Mods {
         /// <summary>
         ///     Saves cache to file.
         /// </summary>
-        void SaveCache();
+        Task SaveCache();
     }
 }

--- a/Arma.Server.Manager/Mods/ModsCache.cs
+++ b/Arma.Server.Manager/Mods/ModsCache.cs
@@ -50,7 +50,7 @@ namespace Arma.Server.Manager.Mods
             {
                 var modInCache = Mods.Single(cacheMod => cacheMod.Equals(mod));
                 return TryEnsureModDirectory(modInCache);
-            } catch (InvalidOperationException e)
+            } catch (InvalidOperationException)
             {
                 mod = TryEnsureModDirectory(mod);
                 Mods.Append(mod);

--- a/Arma.Server.Manager/Mods/ModsCache.cs
+++ b/Arma.Server.Manager/Mods/ModsCache.cs
@@ -3,66 +3,90 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Threading.Tasks;
 using Arma.Server.Config;
 using Arma.Server.Mod;
 using CSharpFunctionalExtensions;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
-namespace Arma.Server.Manager.Mods {
-    public class ModsCache : IModsCache {
-        private readonly IFileSystem _fileSystem;
+namespace Arma.Server.Manager.Mods
+{
+    public class ModsCache : IModsCache
+    {
         private readonly string _cacheFilePath;
+        private readonly IFileSystem _fileSystem;
         private readonly string _modsPath;
 
-        /// <inheritdoc />
-        public ISet<IMod> Mods { get; }
-
-        public ModsCache(ISettings settings, IFileSystem fileSystem = null) {
+        public ModsCache(ISettings settings, IFileSystem fileSystem = null)
+        {
             _fileSystem = fileSystem ?? new FileSystem();
             _modsPath = settings.ModsDirectory;
             _cacheFilePath = $"{_modsPath}\\{settings.ModsManagerCacheFileName}.json";
+
+            // Blocking on asynchronous code as it's only done once at app startup
             Mods = LoadCache()
+                .Result
                 .OnFailureCompensate(x => BuildCache())
                 .Value;
-            SaveCache();
+            SaveCache().Wait();
         }
 
         /// <inheritdoc />
-        public bool ModExists(IMod mod) 
-            => GetOrSetModInCache(mod).Exists(_fileSystem);
+        public ISet<IMod> Mods { get; protected set; }
 
-        private IMod GetOrSetModInCache(IMod mod) {
-            try {
+        /// <inheritdoc />
+        public bool ModExists(IMod mod) => GetOrSetModInCache(mod).Exists(_fileSystem);
+
+        /// <inheritdoc />
+        public async Task SaveCache() => await SaveCache(Mods);
+
+        public static ModsCache CreateModsCache(IServiceProvider serviceProvider)
+            => new ModsCache(serviceProvider.GetService<ISettings>());
+
+        private IMod GetOrSetModInCache(IMod mod)
+        {
+            try
+            {
                 var modInCache = Mods.Single(cacheMod => cacheMod.Equals(mod));
                 return TryEnsureModDirectory(modInCache);
-            }
-            catch (InvalidOperationException e) {
+            } catch (InvalidOperationException e)
+            {
                 mod = TryEnsureModDirectory(mod);
                 Mods.Append(mod);
                 return mod;
             }
         }
 
-        private IMod TryEnsureModDirectory(IMod mod) {
+        private IMod TryEnsureModDirectory(IMod mod)
+        {
             if (mod.Exists(_fileSystem)) return mod;
             mod.Directory = TryFindModDirectory(_modsPath, mod);
             return mod;
         }
 
-        private string TryFindModDirectory(string modsDirectory, IMod mod) {
+        private string TryFindModDirectory(string modsDirectory, IMod mod)
+        {
             string path;
             path = Path.Join(modsDirectory, mod.WorkshopId.ToString());
             if (_fileSystem.Directory.Exists(path)) return path;
             path = Path.Join(modsDirectory, mod.Name);
             if (_fileSystem.Directory.Exists(path)) return path;
-            path = Path.Join(modsDirectory, string.Join("", "@", mod.Name));
+            path = Path.Join(
+                modsDirectory,
+                string.Join(
+                    "",
+                    "@",
+                    mod.Name));
             if (_fileSystem.Directory.Exists(path)) return path;
             return null;
         }
 
-        private Result<ISet<IMod>> LoadCache() {
-            if (!_fileSystem.File.Exists(_cacheFilePath)) return Result.Failure<ISet<IMod>>("Cache file does not exist.");
-            var jsonString = _fileSystem.File.ReadAllText(_cacheFilePath);
+        private async Task<Result<ISet<IMod>>> LoadCache()
+        {
+            if (!_fileSystem.File.Exists(_cacheFilePath))
+                return Result.Failure<ISet<IMod>>("Cache file does not exist.");
+            var jsonString = await _fileSystem.File.ReadAllTextAsync(_cacheFilePath);
             var mods = JsonConvert.DeserializeObject<IEnumerable<Mod.Mod>>(jsonString)
                 .Cast<IMod>()
                 .ToHashSet();
@@ -70,35 +94,34 @@ namespace Arma.Server.Manager.Mods {
             return Result.Success(cachedMods);
         }
 
-        private ISet<IMod> RefreshCache(ISet<IMod> mods) {
+        private ISet<IMod> RefreshCache(ISet<IMod> mods)
+        {
             mods = mods.Where(x => x.Exists(_fileSystem))
                 .ToHashSet();
             return mods;
         }
 
-        private Result<ISet<IMod>> BuildCache() {
-            var mods = (ISet<IMod>)_fileSystem.Directory.GetDirectories(_modsPath)
+        private Result<ISet<IMod>> BuildCache()
+        {
+            var mods = (ISet<IMod>) _fileSystem.Directory.GetDirectories(_modsPath)
                 .Select(CreateModFromDirectory)
                 .ToHashSet();
             return Result.Success(mods);
         }
 
-        /// <inheritdoc />
-        public void SaveCache() {
-            SaveCache(Mods);
-        }
+        private async Task SaveCache(ISet<IMod> mods)
+            => await _fileSystem.File.WriteAllTextAsync(_cacheFilePath, JsonConvert.SerializeObject(mods));
 
-        private void SaveCache(ISet<IMod> mods) {
-            _fileSystem.File.WriteAllText(_cacheFilePath, JsonConvert.SerializeObject(mods));
-        }
-
-        private IMod CreateModFromDirectory(string directoryPath) {
+        private IMod CreateModFromDirectory(string directoryPath)
+        {
             var directoryName = directoryPath.Split('\\').Last();
             var mod = new Mod.Mod();
-            try {
+            try
+            {
                 mod.WorkshopId = int.Parse(directoryName);
                 mod.Source = ModSource.SteamWorkshop;
-            } catch (FormatException) {
+            } catch (FormatException)
+            {
                 mod.Name = directoryName;
                 mod.Source = ModSource.Directory;
             }

--- a/Arma.Server.Manager/Mods/ModsManager.cs
+++ b/Arma.Server.Manager/Mods/ModsManager.cs
@@ -1,76 +1,85 @@
 ﻿using System;
-using Arma.Server.Config;
-using Arma.Server.Mod;
-using Arma.Server.Modset;
-using CSharpFunctionalExtensions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Arma.Server.Config;
 using Arma.Server.Manager.Clients.Steam;
+using Arma.Server.Mod;
+using Arma.Server.Modset;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.DependencyInjection;
 
-namespace Arma.Server.Manager.Mods {
+namespace Arma.Server.Manager.Mods
+{
     /// <inheritdoc />
-    public class ModsManager : IModsManager {
-        private readonly ISteamClient _steamClient;
+    public class ModsManager : IModsManager
+    {
         private readonly IModsCache _modsCache;
+        private readonly ISteamClient _steamClient;
 
         /// <inheritdoc />
-        public ModsManager(ISettings settings) : this(new SteamClient(settings), new ModsCache(settings)){}
+        public ModsManager(ISettings settings) : this(new SteamClient(settings), new ModsCache(settings))
+        {
+        }
 
         /// <inheritdoc cref="ModsManager" />
         /// <param name="steamClient">Steam client for mods download and updating.</param>
         /// <param name="modsCache">Installed mods cache.</param>
-        public ModsManager(ISteamClient steamClient, IModsCache modsCache) {
+        public ModsManager(ISteamClient steamClient, IModsCache modsCache)
+        {
             _steamClient = steamClient;
             _modsCache = modsCache;
         }
 
         /// <inheritdoc />
-        public Result PrepareModset(IModset modset) 
-            => InitializeMods(modset);
+        public Result PrepareModset(IModset modset) => InitializeMods(modset);
 
         /// <inheritdoc />
         public async Task UpdateAllMods(CancellationToken cancellationToken)
-        {
-            await UpdateMods(_modsCache.Mods, cancellationToken);
-        }
-
-        private Result InitializeMods(IModset modset) {
-            return CheckModsExist(modset.Mods)
-                .TapIf(x => x.Any(), async x => await DownloadMods(x, CancellationToken.None)).Result
-                .Bind(x => CheckModsUpdated(modset.Mods))
-                .TapIf(x => x.Any(), async x => await UpdateMods(x, CancellationToken.None)).Result;
-        }
+            => await UpdateMods(_modsCache.Mods, cancellationToken);
 
         /// <inheritdoc />
-        public Result<IEnumerable<IMod>> CheckModsExist(IEnumerable<IMod> modsList) {
+        public Result<IEnumerable<IMod>> CheckModsExist(IEnumerable<IMod> modsList)
+        {
             var missingMods = modsList.Where(mod => !_modsCache.ModExists(mod));
             return Result.Success(missingMods);
         }
 
         /// <inheritdoc />
-        public Result<IEnumerable<IMod>> CheckModsUpdated(IEnumerable<IMod> modsList) {
+        public Result<IEnumerable<IMod>> CheckModsUpdated(IEnumerable<IMod> modsList)
+        {
             var modsRequireUpdate = modsList.Where(ModRequiresUpdate);
             return Result.Success(modsRequireUpdate);
         }
 
-        private bool ModRequiresUpdate(IMod mod)
-            => false;
+        public static ModsManager CreateModsManager(IServiceProvider serviceProvider)
+            => new ModsManager(serviceProvider.GetService<ISteamClient>(), serviceProvider.GetService<IModsCache>());
+
+        private Result InitializeMods(IModset modset)
+            => CheckModsExist(modset.Mods)
+                .TapIf(x => x.Any(), async x => await DownloadMods(x, CancellationToken.None))
+                .Result
+                .Bind(x => CheckModsUpdated(modset.Mods))
+                .TapIf(x => x.Any(), async x => await UpdateMods(x, CancellationToken.None))
+                .Result;
+
+        private bool ModRequiresUpdate(IMod mod) => false;
 
         /// <summary>
-        /// Invokes <see cref="ISteamClient"/> to download given list of mods.
+        ///     Invokes <see cref="ISteamClient" /> to download given list of mods.
         /// </summary>
         /// <param name="missingMods">Mods to download.</param>
-        /// /// <param name="cancellationToken"><see cref="CancellationToken"/> used for mods download safe cancelling.</param>
+        /// ///
+        /// <param name="cancellationToken"><see cref="CancellationToken" /> used for mods download safe cancelling.</param>
         private async Task DownloadMods(IEnumerable<IMod> missingMods, CancellationToken cancellationToken)
             => _steamClient.Download(missingMods.Select(x => x.WorkshopId), cancellationToken);
 
         /// <summary>
-        /// Invokes <see cref="ISteamClient"/> to update given list of mods.
+        ///     Invokes <see cref="ISteamClient" /> to update given list of mods.
         /// </summary>
         /// <param name="requiredUpdateMods">Mods to update.</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> used for mods update safe cancelling.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken" /> used for mods update safe cancelling.</param>
         private async Task UpdateMods(IEnumerable<IMod> requiredUpdateMods, CancellationToken cancellationToken)
             => await _steamClient.Download(requiredUpdateMods.Select(x => x.WorkshopId), cancellationToken);
     }

--- a/Arma.Server.Manager/Program.cs
+++ b/Arma.Server.Manager/Program.cs
@@ -31,9 +31,9 @@ namespace Arma.Server.Manager
 
                     services.AddHostedService<ModsUpdateService>();
 
-                    services.AddSingleton<IHangfireBackgroundJobClient>();
-                    services.AddSingleton<IHangfireJobStorage>();
-                    services.AddSingleton<IHangfireManager>();
+                    services.AddSingleton<IHangfireBackgroundJobClient>(HangfireBackgroundJobClient.CreateHangfireBackgroundJobClient);
+                    services.AddSingleton<IHangfireJobStorage>(HangfireJobStorage.CreateHangfireJobStorage);
+                    services.AddSingleton<IHangfireManager>(HangfireManager.CreateHangfireManager);
                 });
     }
 }

--- a/Arma.Server.Manager/Program.cs
+++ b/Arma.Server.Manager/Program.cs
@@ -1,5 +1,8 @@
+using Arma.Server.Config;
+using Arma.Server.Manager.Clients.Steam;
 using Arma.Server.Manager.Features.Hangfire;
 using Arma.Server.Manager.Features.Hangfire.Helpers;
+using Arma.Server.Manager.Mods;
 using Arma.Server.Manager.Services;
 using Hangfire;
 using Hangfire.LiteDB;
@@ -11,29 +14,35 @@ namespace Arma.Server.Manager
 {
     public class Program
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+        public static void Main(string[] args) => CreateHostBuilder(args).Build().Run();
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureServices((hostContext, services) => {
-                    // Add Hangfire services.
-                    services.AddHangfire(configuration => configuration
-                        .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
-                        .UseSimpleAssemblyNameTypeSerializer()
-                        .UseRecommendedSerializerSettings()
-                        .UseLiteDbStorage(hostContext.Configuration.GetConnectionString("HangfireConnection")));
+        public static IHostBuilder CreateHostBuilder(string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureServices(
+                    (hostContext, services) =>
+                    {
+                        // Add Hangfire services.
+                        services.AddHangfire(
+                            configuration => configuration
+                                .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
+                                .UseSimpleAssemblyNameTypeSerializer()
+                                .UseRecommendedSerializerSettings()
+                                .UseLiteDbStorage(hostContext.Configuration.GetConnectionString("HangfireConnection")));
 
-                    // Add the processing server as IHostedService
-                    services.AddHangfireServer();
+                        // Add the processing server as IHostedService
+                        services.AddHangfireServer();
 
-                    services.AddHostedService<ModsUpdateService>();
+                        services.AddHostedService<ModsUpdateService>();
 
-                    services.AddSingleton<IHangfireBackgroundJobClient>(HangfireBackgroundJobClient.CreateHangfireBackgroundJobClient);
-                    services.AddSingleton<IHangfireJobStorage>(HangfireJobStorage.CreateHangfireJobStorage);
-                    services.AddSingleton<IHangfireManager>(HangfireManager.CreateHangfireManager);
-                });
+                        services.AddSingleton<ISettings>(Settings.LoadSettings);
+                        services.AddSingleton<IModsCache>(ModsCache.CreateModsCache);
+                        services.AddSingleton<IModsManager>(ModsManager.CreateModsManager);
+                        services.AddSingleton<ISteamClient>(SteamClient.CreateSteamClient);
+
+                        services.AddSingleton<IHangfireBackgroundJobClient>(
+                            HangfireBackgroundJobClient.CreateHangfireBackgroundJobClient);
+                        services.AddSingleton<IHangfireJobStorage>(HangfireJobStorage.CreateHangfireJobStorage);
+                        services.AddSingleton<IHangfireManager>(HangfireManager.CreateHangfireManager);
+                    });
     }
 }

--- a/Arma.Server.Manager/Program.cs
+++ b/Arma.Server.Manager/Program.cs
@@ -38,6 +38,7 @@ namespace Arma.Server.Manager
                         services.AddSingleton<IModsCache>(ModsCache.CreateModsCache);
                         services.AddSingleton<IModsManager>(ModsManager.CreateModsManager);
                         services.AddSingleton<ISteamClient>(SteamClient.CreateSteamClient);
+                        services.AddSingleton<IModsDownloader>(ModsDownloader.CreateModsDownloader);
 
                         services.AddSingleton<IHangfireBackgroundJobClient>(
                             HangfireBackgroundJobClient.CreateHangfireBackgroundJobClient);

--- a/Arma.Server.Manager/Services/ModsUpdateService.cs
+++ b/Arma.Server.Manager/Services/ModsUpdateService.cs
@@ -4,35 +4,48 @@ using System.Threading.Tasks;
 using Arma.Server.Config;
 using Arma.Server.Manager.Mods;
 using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Arma.Server.Manager.Services {
+namespace Arma.Server.Manager.Services
+{
     /// <summary>
-    /// Schedules recurring job for updating all cached mods.
+    ///     Schedules recurring job for updating all cached mods.
     /// </summary>
-    public class ModsUpdateService : IHostedService {
+    public class ModsUpdateService : IHostedService
+    {
+        private readonly IModsManager _modsManager;
+        private readonly ISettings _settings;
+        private bool _lock;
+
+        public ModsUpdateService(ISettings settings, IModsManager modsManager)
+        {
+            _settings = settings;
+            _modsManager = modsManager;
+        }
+
         /// <inheritdoc />
-        public Task StartAsync(CancellationToken cancellationToken) {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
             RecurringJob.AddOrUpdate<ModsUpdateService>(x => x.Update(CancellationToken.None), Cron.Hourly);
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task StopAsync(CancellationToken cancellationToken) {
-            return Task.CompletedTask;
-        }
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public static ModsUpdateService CreateModsUpdateService(IServiceProvider serviceProvider)
+            => new ModsUpdateService(
+                serviceProvider.GetService<ISettings>(),
+                serviceProvider.GetService<IModsManager>());
 
         /// <summary>
-        /// Handles updating all cached mods.
+        ///     Handles updating all cached mods.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token for safe process abort.</param>
-        /// <returns>Awaitable <see cref="Task"/></returns>
+        /// <returns>Awaitable <see cref="Task" /></returns>
+        [MaximumConcurrentExecutions(1)]
         public async Task Update(CancellationToken cancellationToken)
-        {
-            ISettings settings = new Settings();
-            settings.LoadSettings();
-            var modsManager = new ModsManager(settings);
-            await modsManager.UpdateAllMods(cancellationToken);
-        }
+            => await _modsManager.UpdateAllMods(cancellationToken);
     }
 }

--- a/Arma.Server.Manager/Services/ModsUpdateService.cs
+++ b/Arma.Server.Manager/Services/ModsUpdateService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Arma.Server.Config;
 using Arma.Server.Manager.Mods;
 using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,12 +14,9 @@ namespace Arma.Server.Manager.Services
     public class ModsUpdateService : IHostedService
     {
         private readonly IModsManager _modsManager;
-        private readonly ISettings _settings;
-        private bool _lock;
 
-        public ModsUpdateService(ISettings settings, IModsManager modsManager)
+        public ModsUpdateService(IModsManager modsManager)
         {
-            _settings = settings;
             _modsManager = modsManager;
         }
 
@@ -35,9 +31,7 @@ namespace Arma.Server.Manager.Services
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public static ModsUpdateService CreateModsUpdateService(IServiceProvider serviceProvider)
-            => new ModsUpdateService(
-                serviceProvider.GetService<ISettings>(),
-                serviceProvider.GetService<IModsManager>());
+            => new ModsUpdateService(serviceProvider.GetService<IModsManager>());
 
         /// <summary>
         ///     Handles updating all cached mods.

--- a/Arma.Server.Test/Arma.Server.Test.csproj
+++ b/Arma.Server.Test/Arma.Server.Test.csproj
@@ -8,15 +8,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.13.0" />
+    <PackageReference Include="AutoFixture" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.2.7" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.7" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Arma.Server/Arma.Server.csproj
+++ b/Arma.Server/Arma.Server.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSharpFunctionalExtensions" Version="2.11.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.2.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArmaServerManager.sln.DotSettings
+++ b/ArmaServerManager.sln.DotSettings
@@ -5,4 +5,5 @@
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File04E3652C4C29A24399350EE3915AA9C7/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File04E3652C4C29A24399350EE3915AA9C7/RelativePriority/@EntryValue">1</s:Double>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hangfire/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modset/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modset/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modsets/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ArmaServerManager.sln.DotSettings
+++ b/ArmaServerManager.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=04E3652C4C29A24399350EE3915AA9C7/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File04E3652C4C29A24399350EE3915AA9C7/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File04E3652C4C29A24399350EE3915AA9C7/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Downloader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hangfire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modsets/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
When merged this PR will:
- [x] Add everything required to update mods to DI with appropriate factory methods.
- [x] Rename `Downloader` to `ModsDownloader`
- [x] `ModsDownloader` use `SteamClient` to remove cyclical dependency
- [x] Fix only first mod update job passed successfully, rest failed with InvalidSteamCredentials.
- [x] `SteamClient` now handles just connecting/disconnecting from Steam
- [x] Update packages