### PR TITLE
Add Headless Client password parameter

### DIFF
--- a/Arma.Server.Test/Providers/Parameters/HeadlessParametersProviderTests.cs
+++ b/Arma.Server.Test/Providers/Parameters/HeadlessParametersProviderTests.cs
@@ -22,6 +22,7 @@ namespace Arma.Server.Test.Providers.Parameters
             var serverCfgPath = _fixture.Create<string>();
             var basicCfgPath = _fixture.Create<string>();
             var port = _fixture.Create<int>();
+            var serverPassword = _fixture.Create<string>();
 
             var modset = ModsetHelpers.CreateTestModset(_fixture);
             var requiredAndServerModsDirectories = modset.Mods
@@ -32,6 +33,7 @@ namespace Arma.Server.Test.Providers.Parameters
             modsetConfigMock.Setup(x => x.HCProfileDirectory).Returns(hcProfileDirectory);
             modsetConfigMock.Setup(x => x.ServerCfg).Returns(serverCfgPath);
             modsetConfigMock.Setup(x => x.BasicCfg).Returns(basicCfgPath);
+            modsetConfigMock.Setup(x => x.ServerPassword).Returns(serverPassword);
 
             var parametersProvider = new HeadlessParametersProvider(
                 port,
@@ -47,7 +49,7 @@ namespace Arma.Server.Test.Providers.Parameters
                 .And.Subject.Should()
                 .Contain($"port={port}")
                 .And.Subject.Should()
-                .Contain("-password=PLACEHOLDER")
+                .Contain($"-password={serverPassword}")
                 .And.Subject.Should()
                 .Contain($"-profiles=\"{hcProfileDirectory}\"")
                 .And.Subject.Should()

--- a/Arma.Server/Config/IModsetConfig.cs
+++ b/Arma.Server/Config/IModsetConfig.cs
@@ -1,5 +1,6 @@
 ﻿namespace Arma.Server.Config {
-    public interface IModsetConfig : IConfig {
+    public interface IModsetConfig : IConfig
+    {
 
         /// <summary>
         /// Path to config.json file.
@@ -20,5 +21,10 @@
         /// Path to Server profile directory.
         /// </summary>
         string ServerProfileDirectory { get; }
+
+        /// <summary>
+        /// Password to enter the server.
+        /// </summary>
+        string ServerPassword { get; }
     }
 }

--- a/Arma.Server/Config/ModsetConfig.cs
+++ b/Arma.Server/Config/ModsetConfig.cs
@@ -17,6 +17,7 @@ namespace Arma.Server.Config
         public string ModsetName { get; protected set; }
         public string ServerCfg { get; protected set; }
         public string ServerProfileDirectory { get; protected set; }
+        public string ServerPassword { get; protected set; }
 
         private readonly IConfig _serverConfig;
         private readonly IFileSystem _fileSystem;
@@ -96,6 +97,8 @@ namespace Arma.Server.Config
                 .AddJsonStream(_fileSystem.FileStream.Create(_serverConfig.ConfigJson, FileMode.Open))
                 .AddJsonStream(_fileSystem.FileStream.Create(ConfigJson, FileMode.Open))
                 .Build();
+
+            ServerPassword = modsetConfig["server:password"] ?? string.Empty;
 
             CreateConfigFiles(_serverConfig.BasicCfg, BasicCfg, modsetConfig);
             CreateConfigFiles(_serverConfig.ServerCfg, ServerCfg, modsetConfig);

--- a/Arma.Server/Mod/Mod.cs
+++ b/Arma.Server/Mod/Mod.cs
@@ -32,5 +32,12 @@ namespace Arma.Server.Mod {
             if (ReferenceEquals(this, mod)) return true;
             return Source == mod.Source && (WorkshopId == mod.WorkshopId || Name == mod.Name);
         }
+
+        public override int GetHashCode()
+        {
+            return Source == ModSource.SteamWorkshop
+                ? WorkshopId
+                : Name.GetHashCode();
+        }
     }
 }

--- a/Arma.Server/Providers/Parameters/HeadlessParametersProvider.cs
+++ b/Arma.Server/Providers/Parameters/HeadlessParametersProvider.cs
@@ -28,7 +28,7 @@ namespace Arma.Server.Providers.Parameters
                 "-client",
                 "-connect=127.0.0.1",
                 $"-port={_port}",
-                "-password=PLACEHOLDER", // TODO: Get password from server.cfg
+                $"-password={_modsetConfig.ServerPassword}", // TODO: Get password from server.cfg
                 $"-profiles=\"{_modsetConfig.HCProfileDirectory}\"",
                 "-limitFPS=100",
                 GetModsStartupParam(_modset));

--- a/Arma.Server/Providers/Parameters/HeadlessParametersProvider.cs
+++ b/Arma.Server/Providers/Parameters/HeadlessParametersProvider.cs
@@ -28,7 +28,7 @@ namespace Arma.Server.Providers.Parameters
                 "-client",
                 "-connect=127.0.0.1",
                 $"-port={_port}",
-                $"-password={_modsetConfig.ServerPassword}", // TODO: Get password from server.cfg
+                $"-password={_modsetConfig.ServerPassword}",
                 $"-profiles=\"{_modsetConfig.HCProfileDirectory}\"",
                 "-limitFPS=100",
                 GetModsStartupParam(_modset));


### PR DESCRIPTION
When merged this PR will:
- Add `ServerPassword` to `ModsetConfig`
- Use `ServerPassword` in `HeadlessClientParametersProvider`