### PR TITLE
Fix mods downloading and verifying

### DIFF
--- a/Arma.Server.Manager.Test/Features/Mods/ModsManagerTests.cs
+++ b/Arma.Server.Manager.Test/Features/Mods/ModsManagerTests.cs
@@ -39,6 +39,9 @@ namespace Arma.Server.Manager.Test.Features.Mods {
             _downloaderMock.Setup(x => x.DownloadOrUpdateMods(It.IsAny<IEnumerable<IMod>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new List<Result<IMod>> { Result.Success((IMod) new Mod.Mod()) }));
 
+            _contentVerifierMock.Setup(x => x.ItemIsUpToDate(It.IsAny<ContentItem>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Result.Failure<ContentItem>("Item requires update")));
+
             await _modsManager.PrepareModset(_modset, CancellationToken.None);
 
             _downloaderMock.Verify(x => x.DownloadOrUpdateMods(
@@ -55,6 +58,9 @@ namespace Arma.Server.Manager.Test.Features.Mods {
 
             _downloaderMock.Setup(x => x.DownloadOrUpdateMods(It.IsAny<IEnumerable<IMod>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new List<Result<IMod>> { Result.Success((IMod)new Mod.Mod()) }));
+
+            _contentVerifierMock.Setup(x => x.ItemIsUpToDate(It.IsAny<ContentItem>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Result.Failure<ContentItem>("Item requires update")));
 
             await _modsManager.PrepareModset(_modset, CancellationToken.None);
 

--- a/Arma.Server.Manager/Constants/SteamConstants.cs
+++ b/Arma.Server.Manager/Constants/SteamConstants.cs
@@ -2,8 +2,11 @@
 {
     public class SteamConstants
     {
-        public const int ArmaAppId = 233780;
+        public const int ArmaAppId = 107410;
+        
+        public const int ArmaServerAppId = 233780;
 
-        public const int ArmaDepotId = 228990;
+        public const int ArmaDepotId = ArmaAppId;
+        //public const int ArmaDepotId = 228990;
     }
 }

--- a/Arma.Server.Manager/Features/Mods/IModsCache.cs
+++ b/Arma.Server.Manager/Features/Mods/IModsCache.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Arma.Server.Manager.Clients.Modsets.Entities;
 using Arma.Server.Mod;
@@ -31,6 +31,6 @@ namespace Arma.Server.Manager.Features.Mods {
         ///     Adds <paramref name="mod"/> to mods cache and saves it.
         /// </summary>
         /// <param name="mod"></param>
-        Task<Result<IEnumerable<IMod>>> AddOrUpdateCache(IEnumerable<IMod> mod);
+        Task<Result<List<IMod>>> AddOrUpdateCache(IEnumerable<IMod> mod);
     }
 }

--- a/Arma.Server.Manager/Features/Mods/IModsManager.cs
+++ b/Arma.Server.Manager/Features/Mods/IModsManager.cs
@@ -28,7 +28,7 @@ namespace Arma.Server.Manager.Features.Mods {
         /// </summary>
         /// <param name="modsList">List of mods to check.</param>
         /// <returns><see cref="Result{T}"/> with outdated mods.</returns>
-        Result<IEnumerable<IMod>> CheckModsUpdated(IEnumerable<IMod> modsList);
+        Task<Result<List<IMod>>> CheckModsUpdated(IEnumerable<IMod> modsList, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates all installed mods.

--- a/Arma.Server.Manager/Features/Mods/ModsCache.cs
+++ b/Arma.Server.Manager/Features/Mods/ModsCache.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -116,7 +116,7 @@ namespace Arma.Server.Manager.Features.Mods
 
         private IMod UpdateModInCache(IMod mod)
         {
-            var modInCache = Mods.Single(x => x == mod);
+            var modInCache = Mods.Single(x => x.Equals(mod));
 
             Mods.Remove(modInCache);
             var newMod = new Mod.Mod
@@ -135,9 +135,9 @@ namespace Arma.Server.Manager.Features.Mods
             return AddModToCache(newMod);
         }
 
-        public async Task<Result<IEnumerable<IMod>>> AddOrUpdateCache(IEnumerable<IMod> mods)
+        public async Task<Result<List<IMod>>> AddOrUpdateCache(IEnumerable<IMod> mods)
         {
-            var cacheMods = mods.Select(AddOrUpdateModInCache);
+            var cacheMods = mods.Select(AddOrUpdateModInCache).ToList();
             await SaveCache();
             return Result.Success(cacheMods);
         }

--- a/Arma.Server.Manager/Features/Steam/Content/IContentVerifier.cs
+++ b/Arma.Server.Manager/Features/Steam/Content/IContentVerifier.cs
@@ -7,6 +7,6 @@ namespace Arma.Server.Manager.Features.Steam.Content
 {
     public interface IContentVerifier
     {
-        Task<Result> ItemIsUpToDate(ContentItem contentItem, CancellationToken cancellationToken);
+        Task<Result<ContentItem>> ItemIsUpToDate(ContentItem contentItem, CancellationToken cancellationToken);
     }
 }

--- a/Arma.Server.Manager/Features/Steam/SteamClient.cs
+++ b/Arma.Server.Manager/Features/Steam/SteamClient.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Arma.Server.Config;
 using BytexDigital.Steam.ContentDelivery;
 using BytexDigital.Steam.Core;
-using Microsoft.Extensions.DependencyInjection;
 using BytexSteamClient = BytexDigital.Steam.Core.SteamClient;
 
 namespace Arma.Server.Manager.Features.Steam
@@ -61,8 +60,5 @@ namespace Arma.Server.Manager.Features.Steam
 
         /// <inheritdoc />
         public void Disconnect() => _bytexSteamClient.Shutdown();
-
-        public static SteamClient CreateSteamClient(IServiceProvider serviceProvider)
-            => new SteamClient(serviceProvider.GetService<ISettings>());
     }
 }

--- a/Arma.Server.Manager/Startup.cs
+++ b/Arma.Server.Manager/Startup.cs
@@ -53,11 +53,12 @@ namespace Arma.Server.Manager
 
             services.AddSingleton<ISettings>(Settings.LoadSettings);
             services.AddSingleton<IModsCache>(ModsCache.CreateModsCache);
-            services.AddSingleton<IModsManager>(ModsManager.CreateModsManager);
+            services.AddSingleton<IModsManager, ModsManager>();
             services.AddSingleton<IApiModsetClient>(ApiModsetClient.CreateApiModsetClient);
             services.AddSingleton<IApiMissionsClient, ApiMissionsClient>();
-            services.AddSingleton<ISteamClient>(SteamClient.CreateSteamClient);
+            services.AddSingleton<ISteamClient, SteamClient>();
             services.AddSingleton<IContentDownloader>(ContentDownloader.CreateContentDownloader);
+            services.AddSingleton<IContentVerifier>(ContentVerifier.CreateContentVerifier);
             services.AddSingleton<IModsetProvider, ModsetProvider>();
             services.AddSingleton<IServerProvider, ServerProvider>();
             services.AddSingleton<IServerConfigurationProvider>(ServerConfigurationProvider.CreateServerConfigurationProvider);


### PR DESCRIPTION
When merged this PR will:
- Include mods verification before downloading
- Fix frequent Task Cancelled exceptions when downloading manifests
- Fix frequent Task Cancelled exceptions when retrieving mod download handler