### PR TITLE
Server start and shutdown fixes and enhancements

### DIFF
--- a/ArmaForces.Arma.Server/Features/Server/ServerProcess.cs
+++ b/ArmaForces.Arma.Server/Features/Server/ServerProcess.cs
@@ -29,7 +29,7 @@ namespace ArmaForces.Arma.Server.Features.Server
             _logger = logger;
         }
 
-        public bool IsStopped => _serverProcess == null;
+        public bool IsStopped => _serverProcess == null || _serverProcess.HasExited;
         
         public bool IsStartingOrStarted => !IsStopped;
 

--- a/ArmaForces.ArmaServerManager/Extensions/RestClientExtensions.cs
+++ b/ArmaForces.ArmaServerManager/Extensions/RestClientExtensions.cs
@@ -17,7 +17,7 @@ namespace ArmaForces.ArmaServerManager.Extensions {
             var response = restClient.Execute<T>(request);
             return response.StatusCode == HttpStatusCode.OK
                 ? response.Data
-                : throw new HttpRequestException(response.StatusCode.ToString());
+                : throw new HttpRequestException(response.ErrorMessage + "|" + response.ErrorException + "|" + response.Content);
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Features/Missions/ApiMissionsClient.cs
+++ b/ArmaForces.ArmaServerManager/Features/Missions/ApiMissionsClient.cs
@@ -48,7 +48,7 @@ namespace ArmaForces.ArmaServerManager.Features.Missions {
                 .ToHashSet();
 
         private IEnumerable<WebMission> ApiMissionsUpcoming() {
-            var requestUri = string.Format(MissionsUpcomingResourceFormat, DateTime.Today);
+            var requestUri = string.Format(MissionsUpcomingResourceFormat, DateTime.Today.ToString("s"));
             var request = new RestRequest(requestUri);
             return _restClient.ExecuteAndReturnData<List<WebMission>>(request);
         }

--- a/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
@@ -49,15 +49,12 @@ namespace ArmaForces.ArmaServerManager.Services
 
         public async Task<Result> StartServer(IModset modset, CancellationToken cancellationToken)
         {
-            await _modsUpdateService.UpdateModset(modset, cancellationToken);
-
-            var server = _serverProvider.GetServer(Port, modset);
-
-            return server.IsServerStopped
-                ? server.Start()
-                : server.Modset == modset 
-                    ? Result.Success()
-                    : Result.Failure($"Server is already running with {server.Modset.Name} modset on port {Port}.");
+            return await ShutdownServer(
+                Port,
+                false,
+                cancellationToken)
+                //.Bind(() => _modsUpdateService.UpdateModset(modset, cancellationToken))
+                .Bind(() => _serverProvider.GetServer(Port, modset).Start());
         }
 
         public async Task<Result> ShutdownServer(int port, bool force, CancellationToken cancellationToken)

--- a/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
@@ -64,7 +64,7 @@ namespace ArmaForces.ArmaServerManager.Services
         {
             var server = _serverProvider.GetServer(port);
 
-            if (server is null) return Result.Success();
+            if (server is null || server.IsServerStopped) return Result.Success();
 
             var serverStatus = await server.GetServerStatusAsync(cancellationToken);
 

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -65,6 +65,7 @@ namespace ArmaForces.ArmaServerManager
             // Mods
             .AddSingleton<IModsCache, ModsCache>()
             .AddSingleton<IModsManager, ModsManager>()
+            .AddSingleton<IModDirectoryFinder, ModDirectoryFinder>()
             .AddSingleton<IApiModsetClient, ApiModsetClient>()
             .AddSingleton<ISteamClient, SteamClient>()
             .AddSingleton<IContentDownloader, ContentDownloader>()


### PR DESCRIPTION
When merged this PR will:
- Remove mods update from startup procedure (as it was taking too long, we need verifying through last updated date instead of verifying all files every time).
- Fix server process shutdown not detected correctly.
- Add ModDirectoryFinder to DI (as it was forgotten)
- Fix DateTime format in ApiMissionsClient
- Add more informations to error message when request fails.