### PR TITLE
Force one job at a time

### DIFF
--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using ArmaForces.Arma.Server.Config;
 using ArmaForces.Arma.Server.Providers.Configuration;
 using ArmaForces.Arma.Server.Providers.Keys;
@@ -62,7 +63,7 @@ namespace ArmaForces.ArmaServerManager
                 .UseLiteDbStorage(Configuration.GetConnectionString("HangfireConnection")))
 
             // Add the processing server as IHostedService
-            .AddHangfireServer()
+            .AddHangfireServer(ConfigureHangfireServer())
 
             .AddHostedService<StartupService>()
 
@@ -140,5 +141,11 @@ namespace ArmaForces.ArmaServerManager
                 endpoints.MapControllers();
             });
         }
+
+        private static Action<BackgroundJobServerOptions> ConfigureHangfireServer()
+            => backgroundJobServerOptions =>
+            {
+                backgroundJobServerOptions.WorkerCount = 1;
+            };
     }
 }


### PR DESCRIPTION
This should enforce one job at a time to prevent accidental server startup if mods are being updated.

This is might get superseded when enhanced status with currently executed job is implemented.