### PR TITLE
Create new server status enum

### DIFF
--- a/ArmaForces.Arma.Server.Tests/Features/Server/DedicatedServerTests.cs
+++ b/ArmaForces.Arma.Server.Tests/Features/Server/DedicatedServerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Config;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.Arma.Server.Features.Server;
+using ArmaForces.Arma.Server.Features.Server.DTOs;
 using ArmaForces.Arma.Server.Providers.Configuration;
 using ArmaForces.Arma.Server.Providers.Keys;
 using AutoFixture;
@@ -52,12 +53,7 @@ namespace ArmaForces.Arma.Server.Tests.Features.Server
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             var serverStatus = await dedicatedServer.GetServerStatusAsync(cancellationTokenSource.Token);
 
-            using (new AssertionScope())
-            {
-                serverStatus.IsServerRunning.Should().BeFalse();
-                serverStatus.IsServerStarting.Should().BeFalse();
-                dedicatedServer.IsServerStopped.Should().BeTrue();
-            }
+            serverStatus.Status.Should().Be(ServerStatusEnum.Stopped);
         }
 
         [Fact]

--- a/ArmaForces.Arma.Server/Features/Server/DTOs/ServerStatus.cs
+++ b/ArmaForces.Arma.Server/Features/Server/DTOs/ServerStatus.cs
@@ -31,11 +31,23 @@ namespace ArmaForces.Arma.Server.Features.Server.DTOs
 
         public int? HeadlessClientsConnected => _dedicatedServer?.HeadlessClientsConnected;
 
-        public bool IsServerStarting => !IsServerRunning && (!_dedicatedServer?.IsServerStopped ?? false);
+        public ServerStatusEnum Status
+        {
+            get
+            {
+                if (!(_serverInfo is null))
+                {
+                    return ServerStatusEnum.Started;
+                }
 
-        public bool IsServerRunning => !(_serverInfo is null);
+                if (!_dedicatedServer?.IsServerStopped ?? false)
+                {
+                    return ServerStatusEnum.Starting;
+                }
 
-        public bool IsServerStopped => _dedicatedServer?.IsServerStopped ?? true;
+                return ServerStatusEnum.Stopped;
+            }
+        }
 
         public string ModsetName => _dedicatedServer?.Modset.Name;
 

--- a/ArmaForces.Arma.Server/Features/Server/DTOs/ServerStatusEnum.cs
+++ b/ArmaForces.Arma.Server/Features/Server/DTOs/ServerStatusEnum.cs
@@ -1,0 +1,11 @@
+﻿namespace ArmaForces.Arma.Server.Features.Server.DTOs
+{
+    public enum ServerStatusEnum
+    {
+        Stopped,
+
+        Starting,
+
+        Started
+    }
+}


### PR DESCRIPTION
It will prevent server status reporting server being started and stopped at the same time. And it's clearer.