### PR TITLE
Make server page work when missions API is down

### DIFF
--- a/ArmaForces.Arma.Server/Features/Mods/ModEqualityComparer.cs
+++ b/ArmaForces.Arma.Server/Features/Mods/ModEqualityComparer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace ArmaForces.Arma.Server.Features.Mods
+{
+    public class ModEqualityComparer : IEqualityComparer<IMod>
+    {
+        public bool Equals(IMod x, IMod y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null) return false;
+            if (y is null) return false;
+            return x.GetType() == y.GetType() && x.Equals(y);
+        }
+
+        public int GetHashCode(IMod obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager.Tests/Features/Missions/ApiMissionsClientTests.cs
+++ b/ArmaForces.ArmaServerManager.Tests/Features/Missions/ApiMissionsClientTests.cs
@@ -22,9 +22,10 @@ namespace ArmaForces.ArmaServerManager.Tests.Features.Missions {
             restClientMock.SetupResponse(HttpStatusCode.OK, expectedMissions);
             var apiClient = new ApiMissionsClient(restClientMock.Object);
 
-            var upcomingMissions = apiClient.GetUpcomingMissions();
+            var result = apiClient.GetUpcomingMissions();
 
-            upcomingMissions.Should().BeEquivalentTo(expectedMissions);
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeEquivalentTo(expectedMissions);
         }
 
         [Fact]
@@ -39,9 +40,10 @@ namespace ArmaForces.ArmaServerManager.Tests.Features.Missions {
             restClientMock.SetupResponse(HttpStatusCode.OK, missions);
             var apiClient = new ApiMissionsClient(restClientMock.Object);
 
-            var upcomingMissionsModsets = apiClient.GetUpcomingMissionsModsets();
+            var result = apiClient.GetUpcomingMissionsModsets();
 
-            upcomingMissionsModsets.Should().BeEquivalentTo(expectedModsets);
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeEquivalentTo(expectedModsets);
         }
 
         private List<WebMission> PrepareMissions(int missionsCount, IReadOnlyList<WebModset> modsets) {

--- a/ArmaForces.ArmaServerManager.Tests/Features/Missions/ApiMissionsClientTests.cs
+++ b/ArmaForces.ArmaServerManager.Tests/Features/Missions/ApiMissionsClientTests.cs
@@ -33,14 +33,14 @@ namespace ArmaForces.ArmaServerManager.Tests.Features.Missions {
             const int modsetsCount = 3;
             const int missionsCount = 6;
             var modsets = _fixture.CreateMany<WebModset>(modsetsCount).ToList();
-            var expectedModsets = modsets.Select(x => new WebModset {Name = x.Name});
+            var expectedModsets = modsets.Select(x => x.Name);
             var missions = PrepareMissions(missionsCount, modsets);
 
             var restClientMock = new Mock<IRestClient>();
             restClientMock.SetupResponse(HttpStatusCode.OK, missions);
             var apiClient = new ApiMissionsClient(restClientMock.Object);
 
-            var result = apiClient.GetUpcomingMissionsModsets();
+            var result = apiClient.GetUpcomingMissionsModsetsNames();
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().BeEquivalentTo(expectedModsets);

--- a/ArmaForces.ArmaServerManager/Extensions/HttpStatusCodeExtensions.cs
+++ b/ArmaForces.ArmaServerManager/Extensions/HttpStatusCodeExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Net;
+
+namespace ArmaForces.ArmaServerManager.Extensions
+{
+    public static class HttpStatusCodeExtensions
+    {
+        public static bool IsSuccessStatusCode(this HttpStatusCode statusCode)
+        {
+            var intStatusCode = (int) statusCode;
+            return intStatusCode >= 200 && intStatusCode <= 299;
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/Extensions/RestClientExtensions.cs
+++ b/ArmaForces.ArmaServerManager/Extensions/RestClientExtensions.cs
@@ -1,5 +1,6 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http;
+using CSharpFunctionalExtensions;
 using RestSharp;
 
 namespace ArmaForces.ArmaServerManager.Extensions {
@@ -18,6 +19,15 @@ namespace ArmaForces.ArmaServerManager.Extensions {
             return response.StatusCode == HttpStatusCode.OK
                 ? response.Data
                 : throw new HttpRequestException(response.ErrorMessage + "|" + response.ErrorException + "|" + response.Content);
+        }
+
+        public static Result<T> ExecuteAndReturnResult<T>(this IRestClient restClient, IRestRequest request)
+            where T : new()
+        {
+            var response = restClient.Execute<T>(request);
+            return response.IsSuccessful
+                ? Result.Success(response.Data)
+                : Result.Failure<T>(response.ErrorMessage);
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Extensions/RestClientExtensions.cs
+++ b/ArmaForces.ArmaServerManager/Extensions/RestClientExtensions.cs
@@ -18,16 +18,16 @@ namespace ArmaForces.ArmaServerManager.Extensions {
             var response = restClient.Execute<T>(request);
             return response.StatusCode == HttpStatusCode.OK
                 ? response.Data
-                : throw new HttpRequestException(response.ErrorMessage + "|" + response.ErrorException + "|" + response.Content);
+                : throw new HttpRequestException(response.GetErrorString());
         }
 
         public static Result<T> ExecuteAndReturnResult<T>(this IRestClient restClient, IRestRequest request)
             where T : new()
         {
             var response = restClient.Execute<T>(request);
-            return response.IsSuccessful
+            return response.StatusCode.IsSuccessStatusCode()
                 ? Result.Success(response.Data)
-                : Result.Failure<T>(response.ErrorMessage);
+                : Result.Failure<T>(response.GetErrorString());
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Extensions/RestResponseExtensions.cs
+++ b/ArmaForces.ArmaServerManager/Extensions/RestResponseExtensions.cs
@@ -1,0 +1,17 @@
+﻿using RestSharp;
+
+namespace ArmaForces.ArmaServerManager.Extensions
+{
+    internal static class RestResponseExtensions
+    {
+        public static string GetErrorString<T>(this IRestResponse<T> response)
+        {
+            if (string.IsNullOrWhiteSpace(response.ErrorMessage))
+            {
+                return response.Content;
+            }
+
+            return response.ErrorMessage + "|" + response.ErrorException;
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/Features/Missions/ApiMissionsClient.cs
+++ b/ArmaForces.ArmaServerManager/Features/Missions/ApiMissionsClient.cs
@@ -41,16 +41,16 @@ namespace ArmaForces.ArmaServerManager.Features.Missions {
             => ApiMissionsUpcoming();
 
         /// <inheritdoc />
-        public Result<ISet<WebModset>> GetUpcomingMissionsModsets()
+        public Result<ISet<string>> GetUpcomingMissionsModsetsNames()
         {
             var upcomingMissionsResult = GetUpcomingMissions();
             if (upcomingMissionsResult.IsFailure)
-                return Result.Failure<ISet<WebModset>>("Missions could not be retrieved.");
+                return Result.Failure<ISet<string>>("Missions could not be retrieved.");
 
             return upcomingMissionsResult.Value
                 .GroupBy(x => x.Modlist)
                 .Select(x => x.First())
-                .Select(x => new WebModset {Name = x.Modlist})
+                .Select(x => x.Modlist)
                 .ToHashSet();
         }
 

--- a/ArmaForces.ArmaServerManager/Features/Missions/IApiMissionsClient.cs
+++ b/ArmaForces.ArmaServerManager/Features/Missions/IApiMissionsClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using ArmaForces.ArmaServerManager.Features.Missions.DTOs;
 using ArmaForces.ArmaServerManager.Features.Modsets.DTOs;
+using CSharpFunctionalExtensions;
 
 namespace ArmaForces.ArmaServerManager.Features.Missions {
     /// <summary>
@@ -11,12 +12,12 @@ namespace ArmaForces.ArmaServerManager.Features.Missions {
         /// Retrieves all upcoming missions counting from today.
         /// </summary>
         /// <returns><see cref="IEnumerable{T}"/> of <see cref="WebMission"/></returns>
-        IEnumerable<WebMission> GetUpcomingMissions();
+        Result<List<WebMission>> GetUpcomingMissions();
 
         /// <summary>
         /// Prepares <seealso cref="ISet{T}"/> of <see cref="WebModset"/> for all upcoming missions counting from today.
         /// </summary>
         /// <returns><seealso cref="ISet{T}"/> of <see cref="WebModset"/></returns>
-        ISet<WebModset> GetUpcomingMissionsModsets();
+        Result<ISet<WebModset>> GetUpcomingMissionsModsets();
     }
 }

--- a/ArmaForces.ArmaServerManager/Features/Missions/IApiMissionsClient.cs
+++ b/ArmaForces.ArmaServerManager/Features/Missions/IApiMissionsClient.cs
@@ -18,6 +18,6 @@ namespace ArmaForces.ArmaServerManager.Features.Missions {
         /// Prepares <seealso cref="ISet{T}"/> of <see cref="WebModset"/> for all upcoming missions counting from today.
         /// </summary>
         /// <returns><seealso cref="ISet{T}"/> of <see cref="WebModset"/></returns>
-        Result<ISet<WebModset>> GetUpcomingMissionsModsets();
+        Result<ISet<string>> GetUpcomingMissionsModsetsNames();
     }
 }

--- a/ArmaForces.ArmaServerManager/Features/Mods/IModsCache.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/IModsCache.cs
@@ -14,9 +14,7 @@ namespace ArmaForces.ArmaServerManager.Features.Mods {
         /// <param name="mod">Mod to check if it exists.</param>
         /// <returns>True if mod directory is found.</returns>
         Task<bool> ModExists(IMod mod);
-
-        IModset MapWebModsetToCacheModset(WebModset webModset);
-
+        
         /// <summary>
         /// All cached mods.
         /// TODO: Change to IReadOnlySet after migration to newer .NET.

--- a/ArmaForces.ArmaServerManager/Features/Mods/IModsManager.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/IModsManager.cs
@@ -31,6 +31,13 @@ namespace ArmaForces.ArmaServerManager.Features.Mods {
         Task<Result<List<IMod>>> CheckModsUpdated(IEnumerable<IMod> modsList, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Updates given <paramref name="mods"/>.
+        /// </summary>
+        /// <param name="mods">List of mods to update.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used for task cancellation.</param>
+        Task UpdateMods(IEnumerable<IMod> mods, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Updates all installed mods.
         /// </summary>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used for task cancellation.</param>

--- a/ArmaForces.ArmaServerManager/Features/Mods/IWebModsetMapper.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/IWebModsetMapper.cs
@@ -1,0 +1,10 @@
+﻿using ArmaForces.Arma.Server.Features.Modsets;
+using ArmaForces.ArmaServerManager.Features.Modsets.DTOs;
+
+namespace ArmaForces.ArmaServerManager.Features.Mods
+{
+    public interface IWebModsetMapper
+    {
+        IModset MapWebModsetToCacheModset(WebModset webModset);
+    }
+}

--- a/ArmaForces.ArmaServerManager/Features/Mods/ModsCache.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/ModsCache.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace ArmaForces.ArmaServerManager.Features.Mods
 {
-    public class ModsCache : IModsCache
+    public class ModsCache : IModsCache, IWebModsetMapper
     {
         private readonly IModDirectoryFinder _modDirectoryFinder;
         private readonly IFileSystem _fileSystem;

--- a/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
@@ -35,6 +35,10 @@ namespace ArmaForces.ArmaServerManager.Features.Mods
             => await DownloadMods(modset.Mods, cancellationToken);
 
         /// <inheritdoc />
+        public async Task UpdateMods(IEnumerable<IMod> mods, CancellationToken cancellationToken)
+            => await DownloadMods(mods, cancellationToken);
+
+        /// <inheritdoc />
         public async Task UpdateAllMods(CancellationToken cancellationToken)
             => await DownloadMods(_modsCache.Mods, cancellationToken);
 

--- a/ArmaForces.ArmaServerManager/Pages/Server.cshtml
+++ b/ArmaForces.ArmaServerManager/Pages/Server.cshtml
@@ -25,6 +25,10 @@
                     Select mission to start server:
                     <select name="missionTitle" asp-items="Model.MissionOptions"></select>
                     <br />
+                    @if (Model.MissionOptions is null)
+                    {
+                        <span style="color: red">Missions could not be loaded.</span>
+                    }
                     <br />
                     <input type="submit" value="Start server for mission" />
                 </form>

--- a/ArmaForces.ArmaServerManager/Pages/Server.cshtml.cs
+++ b/ArmaForces.ArmaServerManager/Pages/Server.cshtml.cs
@@ -44,11 +44,8 @@ namespace ArmaForces.ArmaServerManager.Pages
 
         public void OnGet()
         {
-            var modsets = _apiModsetClient.GetModsets();
-            ModsetOptions = new SelectList(modsets, nameof(WebModset.Name), nameof(WebModset.Name));
-
-            var missions = _apiMissionsClient.GetUpcomingMissions();
-            MissionOptions = new SelectList(missions, nameof(WebMission.Title), nameof(WebMission.Title));
+            LoadModsets();
+            LoadMissions();
         }
 
         public async Task OnPost()
@@ -63,6 +60,24 @@ namespace ArmaForces.ArmaServerManager.Pages
                 _hangfireManager.ScheduleJob<ServerStartupService>(
                     x => x.StartServerForMission(MissionTitle, CancellationToken.None));
             }
+
+            // Reload all data to prevent user having to refresh
+            OnGet();
+        }
+
+        private void LoadModsets()
+        {
+            var modsets = _apiModsetClient.GetModsets();
+            ModsetOptions = new SelectList(modsets, nameof(WebModset.Name), nameof(WebModset.Name));
+        }
+
+        private void LoadMissions()
+        {
+            var missionsResult = _apiMissionsClient.GetUpcomingMissions();
+            if (missionsResult.IsFailure) return;
+
+            var missions = missionsResult.Value;
+            MissionOptions = new SelectList(missions, nameof(WebMission.Title), nameof(WebMission.Title));
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Providers/ModsetProvider.cs
+++ b/ArmaForces.ArmaServerManager/Providers/ModsetProvider.cs
@@ -10,25 +10,25 @@ namespace ArmaForces.ArmaServerManager.Providers
     public class ModsetProvider : IModsetProvider
     {
         private readonly IApiModsetClient _apiModsetClient;
-        private readonly IModsCache _modsCache;
+        private readonly IWebModsetMapper _webModsetMapper;
 
-        public ModsetProvider(IApiModsetClient apiModsetClient, IModsCache modsCache)
+        public ModsetProvider(IApiModsetClient apiModsetClient, IWebModsetMapper webModsetMapper)
         {
             _apiModsetClient = apiModsetClient;
-            _modsCache = modsCache;
+            _webModsetMapper = webModsetMapper;
         }
 
         public Result<IModset> GetModsetByName(string modsetName)
         {
             var webModset = _apiModsetClient.GetModsetDataByName(modsetName);
 
-            return Result.Success(_modsCache.MapWebModsetToCacheModset(webModset));
+            return Result.Success(_webModsetMapper.MapWebModsetToCacheModset(webModset));
         }
 
         public Result<IEnumerable<IModset>> GetModsets()
         {
             var modsets = _apiModsetClient.GetModsets()
-                .Select(x => _modsCache.MapWebModsetToCacheModset(x));
+                .Select(x => _webModsetMapper.MapWebModsetToCacheModset(x));
 
             return Result.Success(modsets);
         }

--- a/ArmaForces.ArmaServerManager/Services/IModsUpdateService.cs
+++ b/ArmaForces.ArmaServerManager/Services/IModsUpdateService.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Features.Mods;
 using ArmaForces.Arma.Server.Features.Modsets;
 using CSharpFunctionalExtensions;
 
@@ -10,6 +12,8 @@ namespace ArmaForces.ArmaServerManager.Services
         Task<Result> UpdateModset(string modsetName, CancellationToken cancellationToken);
 
         Task<Result> UpdateModset(IModset modset, CancellationToken cancellationToken);
+
+        Task UpdateMods(IEnumerable<IMod> mods, CancellationToken cancellationToken);
 
         /// <summary>
         ///     Handles updating all cached mods.

--- a/ArmaForces.ArmaServerManager/Services/ModsUpdateService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ModsUpdateService.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Features.Mods;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.ArmaServerManager.Features.Mods;
 using ArmaForces.ArmaServerManager.Providers;
@@ -31,6 +33,11 @@ namespace ArmaForces.ArmaServerManager.Services
         public async Task<Result> UpdateModset(IModset modset, CancellationToken cancellationToken)
         {
             return await _modsManager.PrepareModset(modset, cancellationToken);
+        }
+
+        public async Task UpdateMods(IEnumerable<IMod> mods, CancellationToken cancellationToken)
+        {
+            await _modsManager.UpdateMods(mods, cancellationToken);
         }
 
         /// <summary>

--- a/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
@@ -35,7 +35,10 @@ namespace ArmaForces.ArmaServerManager.Services
 
         public async Task<Result> StartServerForMission(string missionTitle, CancellationToken cancellationToken)
         {
-            var mission = _apiMissionsClient.GetUpcomingMissions()
+            var upcomingMissions = _apiMissionsClient.GetUpcomingMissions();
+            if (upcomingMissions.IsFailure) return Result.Failure("Could not retrieve upcoming missions.");
+
+            var mission = upcomingMissions.Value
                 .Single(x => x.Title == missionTitle);
 
             return await StartServer(mission.Modlist, cancellationToken);

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -81,7 +81,9 @@ namespace ArmaForces.ArmaServerManager
             .AddSingleton<ISettings>(Settings.LoadSettings)
 
             // Mods
-            .AddSingleton<IModsCache, ModsCache>()
+            .AddSingleton<ModsCache>()
+            .AddSingleton<IModsCache>(x => x.GetService<ModsCache>())
+            .AddSingleton<IWebModsetMapper>(x => x.GetService<ModsCache>())
             .AddSingleton<IModsManager, ModsManager>()
             .AddSingleton<IModDirectoryFinder, ModDirectoryFinder>()
             .AddSingleton<IApiModsetClient, ApiModsetClient>()


### PR DESCRIPTION
When merged this PR will:
- title
- Add ability to update collection of mods
- Extract `IWebModsetMapper` interface from `IModsCache`
- Reload server page after submitting server startup to prevent user having to reload it himself

Closes #47 