### PR TITLE
Make server status don't show nulls

### DIFF
--- a/ArmaForces.Arma.Server/Features/Servers/DTOs/ServerStatus.cs
+++ b/ArmaForces.Arma.Server/Features/Servers/DTOs/ServerStatus.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace ArmaForces.Arma.Server.Features.Servers.DTOs
 {
@@ -29,36 +30,43 @@ namespace ArmaForces.Arma.Server.Features.Servers.DTOs
             return new ServerStatus(dedicatedServer, serverInfo);
         }
 
-        public int? HeadlessClientsConnected => _dedicatedServer?.HeadlessClientsConnected;
+        [JsonProperty(Required = Required.Always)]
+        public ServerStatusEnum Status => GetServerStatusEnum();
 
-        public ServerStatusEnum Status
-        {
-            get
-            {
-                if (!(_serverInfo is null))
-                {
-                    return ServerStatusEnum.Started;
-                }
-
-                if (!_dedicatedServer?.IsServerStopped ?? false)
-                {
-                    return ServerStatusEnum.Starting;
-                }
-
-                return ServerStatusEnum.Stopped;
-            }
-        }
-
-        public string? ModsetName => _dedicatedServer?.Modset.Name;
-
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? Name => _serverInfo?.Name;
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string? ModsetName => _dedicatedServer?.Modset.Name;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? Map => _serverInfo?.Map;
 
-        public int Players => _serverInfo?.Players ?? 0;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? Players => _serverInfo?.Players;
 
-        public int PlayersMax => _serverInfo?.MaxPlayers ?? 0;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? PlayersMax => _serverInfo?.MaxPlayers;
 
-        public int Port => _dedicatedServer?.Port ?? 0;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? Port => _dedicatedServer?.Port;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? HeadlessClientsConnected => _dedicatedServer?.HeadlessClientsConnected;
+
+        private ServerStatusEnum GetServerStatusEnum()
+        {
+            if (!(_serverInfo is null))
+            {
+                return ServerStatusEnum.Started;
+            }
+
+            if (!_dedicatedServer?.IsServerStopped ?? false)
+            {
+                return ServerStatusEnum.Starting;
+            }
+
+            return ServerStatusEnum.Stopped;
+        }
     }
 }

--- a/ArmaForces.ArmaServerManager/Services/IServerStartupService.cs
+++ b/ArmaForces.ArmaServerManager/Services/IServerStartupService.cs
@@ -32,7 +32,7 @@ namespace ArmaForces.ArmaServerManager.Services
         /// <returns></returns>
         Task<Result> ShutdownServer(
             int port,
-            bool force,
-            CancellationToken cancellationToken);
+            bool force = false,
+            CancellationToken? cancellationToken = null);
     }
 }

--- a/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
@@ -63,21 +63,23 @@ namespace ArmaForces.ArmaServerManager.Services
                 .Bind(() => _serverProvider.GetServer(Port, modset).Start());
         }
 
-        public async Task<Result> ShutdownServer(int port, bool force, CancellationToken cancellationToken)
+        public async Task<Result> ShutdownServer(
+            int port,
+            bool force = false,
+            CancellationToken? cancellationToken = null)
         {
             var server = _serverProvider.GetServer(port);
 
             if (server is null || server.IsServerStopped) return Result.Success();
 
-            var serverStatus = await server.GetServerStatusAsync(cancellationToken);
+            var serverStatus = await server.GetServerStatusAsync(cancellationToken ?? CancellationToken.None);
 
-            if (serverStatus.Players != 0 && !force)
+            if (serverStatus.Players.HasValue && serverStatus.Players != 0 && !force)
             {
                 return Result.Failure($"Server cannot be shut down, there are {serverStatus.Players} online.");
             }
 
-            server.Shutdown();
-            return Result.Success();
+            return await server.Shutdown();
         }
     }
 }


### PR DESCRIPTION
There is no need to return e.g. players count or server name when its stopped. This PR changes all properties other than status enum to nullable and only relevant info will be returned when server is stopped/starting.