### PR TITLE
Delay consecutive ManifestId download attempts and descrease limit to 3

### DIFF
--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/SteamContentConstants.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/SteamContentConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace ArmaForces.ArmaServerManager.Features.Steam.Content
+{
+    internal class SteamContentConstants
+    {
+        public const int MaximumRetryCount = 3;
+    }
+}


### PR DESCRIPTION
This will:
- Delay download ManifestId attempts by 5 seconds.
- Handle `SteamKit2.AsyncJobFailedException` in a similar way as `TaskCanceledException`.
- Decrease attempts limit to 3 (was 10).