### PR TITLE
Remove redundant mod files during mod files verification

### DIFF
--- a/ArmaForces.ArmaServerManager.Tests/Features/Steam/Content/ContentFileVerifierTests.cs
+++ b/ArmaForces.ArmaServerManager.Tests/Features/Steam/Content/ContentFileVerifierTests.cs
@@ -1,0 +1,137 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using ArmaForces.ArmaServerManager.Features.Steam.Content;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ArmaForces.ArmaServerManager.Tests.Features.Steam.Content
+{
+    public class ContentFileVerifierTests
+    {
+        private readonly string _baseDirectory = Directory.GetCurrentDirectory();
+
+        [Theory, Trait("Category", "Unit")]
+        [ClassData(typeof(ContentFileVerifierTestsDataProvider))]
+        public void RemoveRedundantFiles(IReadOnlyCollection<string> filesPresent, IReadOnlyCollection<string> filesExpected)
+        {
+            var fileSystemMock = new MockFileSystem(CreateTestFileSystem(filesPresent), _baseDirectory);
+            var contentFileVerifier = new ContentFileVerifier(new NullLogger<ContentFileVerifier>(), fileSystemMock);
+
+            contentFileVerifier.RemoveRedundantFiles(_baseDirectory, filesExpected);
+
+            var filesExpectedToBeRemoved = filesPresent
+                .Where(s => !filesExpected.Contains(s));
+
+            using (new AssertionScope())
+            {
+                foreach (var fileExpected in filesExpected)
+                {
+                    if (Path.HasExtension(fileExpected))
+                    {
+                        fileSystemMock.File.Exists(fileExpected).Should().BeTrue();
+                    }
+                    else
+                    {
+                        fileSystemMock.Directory.Exists(fileExpected).Should().BeTrue();
+                    }
+                }
+
+                foreach (var fileExpectedToBeRemoved in filesExpectedToBeRemoved)
+                {
+                    if (Path.HasExtension(fileExpectedToBeRemoved))
+                    {
+                        fileSystemMock.File.Exists(fileExpectedToBeRemoved).Should().BeFalse();
+                    }
+                    else
+                    {
+                        fileSystemMock.Directory.Exists(fileExpectedToBeRemoved).Should().BeFalse();
+                    }
+                }
+            }
+        }
+
+        private static Dictionary<string, MockFileData> CreateTestFileSystem(IEnumerable<string> filesPresent)
+        {
+            return filesPresent
+                .Select(
+                    x => Path.HasExtension(x)
+                        ? new KeyValuePair<string, MockFileData>(x, new MockFileData(string.Empty))
+                        : new KeyValuePair<string, MockFileData>(x, new MockDirectoryData()))
+                .ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        internal class ContentFileVerifierTestsDataProvider : IEnumerable<object[]>
+        {
+            private readonly IEnumerable<object[]> _enumerableImplementation;
+
+            public ContentFileVerifierTestsDataProvider()
+            {
+                _enumerableImplementation = new List<object[]>
+                {
+                    SimpleTestData()
+                };
+            }
+
+            public IEnumerator<object[]> GetEnumerator() => _enumerableImplementation.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable) _enumerableImplementation).GetEnumerator();
+
+            private object[] SimpleTestData()
+            {
+                return new object[]
+                {
+                    ModBaseFilesAndDirectories
+                        .Concat(MainPbo)
+                        .Concat(Test2Pbo)
+                        .Concat(TestBikey)
+                        .Concat(Test2Bikey)
+                        .ToList(),
+                    ModBaseFilesAndDirectories
+                        .Concat(MainPbo)
+                        .Concat(TestBikey)
+                        .ToList()
+                };
+            }
+
+            private List<string> ModBaseFilesAndDirectories => new List<string>
+            {
+                AddonsDirectory,
+                KeysDirectory,
+                ConfigCpp
+            };
+
+            private string AddonsDirectory => "Addons";
+
+            private string KeysDirectory => "Keys";
+
+            private string ConfigCpp => "config.cpp";
+
+            private List<string> MainPbo => new List<string>
+            {
+                Path.Join(AddonsDirectory, "main.pbo"),
+                Path.Join(AddonsDirectory, "main.pbo.bisign")
+            };
+
+            private List<string> Test2Pbo => new List<string>
+            {
+                Path.Join(AddonsDirectory, "test2.pbo"),
+                Path.Join(AddonsDirectory, "test2.pbo.bisign")
+            };
+
+            private List<string> TestBikey => new List<string>
+            {
+                Path.Join(KeysDirectory, "test.bikey")
+            };
+
+            private List<string> Test2Bikey => new List<string>
+            {
+                Path.Join(KeysDirectory, "test2.bikey")
+            };
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/ArmaForces.ArmaServerManager.csproj
+++ b/ArmaForces.ArmaServerManager/ArmaForces.ArmaServerManager.csproj
@@ -26,6 +26,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/ArmaForces.ArmaServerManager/ArmaForces.ArmaServerManager.csproj
+++ b/ArmaForces.ArmaServerManager/ArmaForces.ArmaServerManager.csproj
@@ -29,6 +29,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
@@ -13,7 +13,7 @@ using CSharpFunctionalExtensions;
 namespace ArmaForces.ArmaServerManager.Features.Mods
 {
     /// <inheritdoc />
-    public class ModsManager : IModsManager
+    internal class ModsManager : IModsManager
     {
         private readonly IContentDownloader _contentDownloader;
         private readonly IContentVerifier _contentVerifier;

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentFileVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentFileVerifier.cs
@@ -16,10 +16,10 @@ namespace ArmaForces.ArmaServerManager.Features.Steam.Content
         private readonly ILogger<ContentFileVerifier> _logger;
         private readonly IFileSystem _fileSystem;
 
-        public ContentFileVerifier(ILogger<ContentFileVerifier> logger, IFileSystem fileSystem)
+        public ContentFileVerifier(ILogger<ContentFileVerifier> logger, IFileSystem? fileSystem = null)
         {
             _logger = logger;
-            _fileSystem = fileSystem;
+            _fileSystem = fileSystem ?? new FileSystem();
         }
 
         public Result<ContentItem> EnsureDirectoryExists(ContentItem contentItem)

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentFileVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentFileVerifier.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Security.Cryptography;
+using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
+using BytexDigital.Steam.ContentDelivery.Enumerations;
+using BytexDigital.Steam.ContentDelivery.Models;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
+
+namespace ArmaForces.ArmaServerManager.Features.Steam.Content
+{
+    internal class ContentFileVerifier : IContentFileVerifier
+    {
+        private readonly ILogger<ContentFileVerifier> _logger;
+        private readonly IFileSystem _fileSystem;
+
+        public ContentFileVerifier(ILogger<ContentFileVerifier> logger, IFileSystem fileSystem)
+        {
+            _logger = logger;
+            _fileSystem = fileSystem;
+        }
+
+        public Result<ContentItem> EnsureDirectoryExists(ContentItem contentItem)
+        {
+            if (contentItem.Directory != null && _fileSystem.Directory.Exists(contentItem.Directory))
+            {
+                return Result.Success(contentItem);
+            }
+
+            _logger.LogInformation("Item {contentItemId} doesn't have a directory.");
+            return Result.Failure<ContentItem>("Item not exists.");
+        }
+
+        public void RemoveRedundantFiles(string directory, Manifest manifest)
+        {
+            var filesAndDirectories = manifest.Files
+                .Select(x => x.FileName)
+                .ToList();
+
+            RemoveRedundantFiles(directory, filesAndDirectories);
+        }
+
+        public void RemoveRedundantFiles(string directory, IReadOnlyCollection<string> expectedFilesAndDirectories)
+        {
+            var expectedFiles = expectedFilesAndDirectories
+                .Select(x => Path.Join(directory, x))
+                .ToList();
+
+            var redundantFiles = _fileSystem.Directory.GetFiles(directory, "*", SearchOption.AllDirectories)
+                .Where(x => !expectedFiles.Contains(x))
+                .ToList();
+
+            foreach (var file in redundantFiles)
+            {
+                _fileSystem.File.Delete(file);
+            }
+        }
+
+        public bool FileIsUpToDate(string directory, ManifestFile file)
+        {
+            if (file.Flags == ManifestFileFlag.Directory)
+            {
+                return _fileSystem.Directory.Exists(Path.Join(directory, file.FileName));
+            }
+
+            var filePath = _fileSystem.Path.Combine(directory, file.FileName);
+
+            if (!_fileSystem.File.Exists(filePath)) return false;
+
+            using var fileStream = _fileSystem.FileStream.Create(filePath, FileMode.Open);
+            using var bufferedStream = new BufferedStream(fileStream);
+            using var sha1 = new SHA1Managed();
+
+            var localFileHash = sha1.ComputeHash(bufferedStream);
+
+            return localFileHash.SequenceEqual(file.FileHash);
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentVerifier.cs
@@ -1,95 +1,15 @@
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
-using BytexDigital.Steam.ContentDelivery.Enumerations;
 using BytexDigital.Steam.ContentDelivery.Models;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
 namespace ArmaForces.ArmaServerManager.Features.Steam.Content
 {
-    internal interface IContentFileVerifier
-    {
-        Result<ContentItem> EnsureDirectoryExists(ContentItem contentItem);
-
-        void RemoveRedundantFiles(string directory, Manifest manifest);
-
-        bool FileIsUpToDate(string directory, ManifestFile file);
-    }
-
-    internal class ContentFileVerifier : IContentFileVerifier
-    {
-        private readonly ILogger<ContentFileVerifier> _logger;
-        private readonly IFileSystem _fileSystem;
-
-        public ContentFileVerifier(ILogger<ContentFileVerifier> logger, IFileSystem fileSystem)
-        {
-            _logger = logger;
-            _fileSystem = fileSystem;
-        }
-
-        public Result<ContentItem> EnsureDirectoryExists(ContentItem contentItem)
-        {
-            if (contentItem.Directory != null && _fileSystem.Directory.Exists(contentItem.Directory))
-            {
-                return Result.Success(contentItem);
-            }
-
-            _logger.LogInformation("Item {contentItemId} doesn't have a directory.");
-            return Result.Failure<ContentItem>("Item not exists.");
-        }
-
-        public void RemoveRedundantFiles(string directory, Manifest manifest)
-        {
-            var filesAndDirectories = manifest.Files
-                .Select(x => x.FileName)
-                .ToList();
-
-            RemoveRedundantFiles(directory, filesAndDirectories);
-        }
-
-        public void RemoveRedundantFiles(string directory, IReadOnlyCollection<string> expectedFilesAndDirectories)
-        {
-            var expectedFiles = expectedFilesAndDirectories
-                .Select(x => Path.Join(directory, x))
-                .ToList();
-
-            var redundantFiles = _fileSystem.Directory.GetFiles(directory, "*", SearchOption.AllDirectories)
-                .Where(x => !expectedFiles.Contains(x))
-                .ToList();
-
-            foreach (var file in redundantFiles)
-            {
-                _fileSystem.File.Delete(file);
-            }
-        }
-
-        public bool FileIsUpToDate(string directory, ManifestFile file)
-        {
-            if (file.Flags == ManifestFileFlag.Directory)
-            {
-                return _fileSystem.Directory.Exists(Path.Join(directory, file.FileName));
-            }
-
-            var filePath = _fileSystem.Path.Combine(directory, file.FileName);
-
-            if (!_fileSystem.File.Exists(filePath)) return false;
-
-            using var fileStream = _fileSystem.FileStream.Create(filePath, FileMode.Open);
-            using var bufferedStream = new BufferedStream(fileStream);
-            using var sha1 = new SHA1Managed();
-
-            var localFileHash = sha1.ComputeHash(bufferedStream);
-
-            return localFileHash.SequenceEqual(file.FileHash);
-        }
-    }
-
     internal class ContentVerifier : IContentVerifier
     {
         private readonly IManifestDownloader _manifestDownloader;
@@ -110,26 +30,34 @@ namespace ArmaForces.ArmaServerManager.Features.Steam.Content
             ContentItem contentItem,
             CancellationToken cancellationToken)
         {
-            await _contentFileVerifier.EnsureDirectoryExists(contentItem)
-                .Bind(x => Result.Success(_manifestDownloader.GetManifest(x, cancellationToken)))
-                .Tap(x => x);
-            
-            var manifest = await _manifestDownloader.GetManifest(contentItem, cancellationToken);
+            var incorrectFilesResult = await VerifyAllFiles(contentItem, cancellationToken);
 
-            var incorrectFiles = manifest.Files
-                .SkipWhile(manifestFile => _contentFileVerifier.FileIsUpToDate(contentItem.Directory, manifestFile))
+            return incorrectFilesResult
+                    .Bind(x => x.Any()
+                        ? Result.Failure<ContentItem>("One or more files are either missing or require update.")
+                        : Result.Success(contentItem));
+        }
+
+        private async Task<Result<List<ManifestFile>>> VerifyAllFiles(ContentItem contentItem, CancellationToken cancellationToken)
+        {
+            return await _contentFileVerifier.EnsureDirectoryExists(contentItem)
+                .Bind(x => GetManifest(x, cancellationToken))
+                // TODO: Move redundant files removing out of verification, returning redundant files should be separate from removing them.
+                .Tap(x => _contentFileVerifier.RemoveRedundantFiles(contentItem.Directory!, x))
+                .Bind(manifest => GetIncorrectFiles(contentItem, manifest));
+        }
+
+        private Result<List<ManifestFile>> GetIncorrectFiles(ContentItem contentItem, Manifest manifest)
+        {
+            return manifest.Files
+                .SkipWhile(manifestFile => _contentFileVerifier.FileIsUpToDate(contentItem.Directory!, manifestFile))
                 .ToList();
+        }
 
-            _logger.LogDebug(
-                incorrectFiles.Any()
-                    ? "Found incorrect files for item {contentItemId}."
-                    : "All files are correct for item {contentItemId}.",
-                contentItem.Id);
-
-            return incorrectFiles
-                .Any()
-                ? Result.Failure<ContentItem>("One or more files are either missing or require update.")
-                : Result.Success(contentItem);
+        private async Task<Result<Manifest>> GetManifest(ContentItem contentItem, CancellationToken cancellationToken)
+        {
+            var manifest = await _manifestDownloader.GetManifest(contentItem, cancellationToken);
+            return Result.Success(manifest);
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/IContentFileVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/IContentFileVerifier.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
+using BytexDigital.Steam.ContentDelivery.Models;
+using CSharpFunctionalExtensions;
+
+namespace ArmaForces.ArmaServerManager.Features.Steam.Content
+{
+    internal interface IContentFileVerifier
+    {
+        Result<ContentItem> EnsureDirectoryExists(ContentItem contentItem);
+
+        void RemoveRedundantFiles(string directory, Manifest manifest);
+
+        void RemoveRedundantFiles(string directory, IReadOnlyCollection<string> expectedFilesAndDirectories);
+
+        bool FileIsUpToDate(string directory, ManifestFile file);
+    }
+}

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/IManifestDownloader.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/IManifestDownloader.cs
@@ -1,12 +1,12 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
-using CSharpFunctionalExtensions;
+using BytexDigital.Steam.ContentDelivery.Models;
 
 namespace ArmaForces.ArmaServerManager.Features.Steam.Content
 {
-    internal interface IContentVerifier
+    internal interface IManifestDownloader
     {
-        Task<Result<ContentItem>> ItemIsUpToDate(ContentItem contentItem, CancellationToken cancellationToken);
+        Task<Manifest> GetManifest(ContentItem contentItem, CancellationToken cancellationToken);
     }
 }

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ManifestDownloader.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ManifestDownloader.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ArmaForces.ArmaServerManager.Features.Steam.Constants;
+using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
+using BytexDigital.Steam.ContentDelivery.Models;
+using BytexDigital.Steam.Core.Structs;
+using Microsoft.Extensions.Logging;
+using SteamKit2;
+
+namespace ArmaForces.ArmaServerManager.Features.Steam.Content
+{
+    internal class ManifestDownloader : IManifestDownloader
+    {
+        private readonly ISteamClient _steamClient;
+        private readonly ILogger<ManifestDownloader> _logger;
+
+        public ManifestDownloader(ISteamClient steamClient, ILogger<ManifestDownloader> logger)
+        {
+            _steamClient = steamClient;
+            _logger = logger;
+        }
+
+        public async Task<Manifest> GetManifest(ContentItem contentItem, CancellationToken cancellationToken)
+            => await _steamClient.ContentClient.GetManifestAsync(
+                SteamConstants.ArmaAppId,
+                SteamConstants.ArmaWorkshopDepotId,
+                await GetManifestId(contentItem),
+                cancellationToken);
+
+        /// <summary>
+        /// TODO: Do it better
+        /// </summary>
+        private async Task<ManifestId> GetManifestId(ContentItem contentItem)
+        {
+            _logger.LogDebug("Downloading ManifestId for item {contentItemId}.", contentItem.Id);
+
+            var errors = 0;
+
+            while (true)
+            {
+                try
+                {
+                    return (await _steamClient.ContentClient.GetPublishedFileDetailsAsync(contentItem.Id))
+                        .hcontent_file;
+                }
+                catch (TaskCanceledException exception)
+                {
+                    errors++;
+                    LogManifestIdDownloadFailure(contentItem, exception, errors);
+
+                    if (errors >= SteamContentConstants.MaximumRetryCount)
+                    {
+                        throw CreateManifestDownloadException(errors, contentItem, exception);
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+                catch (AsyncJobFailedException exception)
+                {
+                    errors++;
+                    LogManifestIdDownloadFailure(contentItem, exception, errors);
+
+                    if (errors >= SteamContentConstants.MaximumRetryCount)
+                    {
+                        throw CreateManifestDownloadException(errors, contentItem, exception);
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        private void LogManifestIdDownloadFailure(
+            ContentItem contentItem,
+            Exception exception,
+            int errors)
+            => _logger.LogTrace(
+                exception,
+                "Failed to download ManifestId for item {contentItemId}. Errors = {number}.",
+                contentItem.Id,
+                errors);
+
+        private Exception CreateManifestDownloadException(
+            int errors,
+            ContentItem contentItem,
+            Exception? innerException = null)
+        {
+            var newException = new Exception(
+                $"{errors} errors while attempting to download manifest for {contentItem.Id}",
+                innerException);
+
+            if (innerException is null)
+            {
+                _logger.LogError(
+                    newException,
+                    "Could not download ManifestId for item {contentItemId}.",
+                    contentItem.Id);
+            }
+            else
+            {
+                _logger.LogError(
+                    newException,
+                    "Could not download ManifestId for item {contentItemId}, error message {message}.",
+                    contentItem.Id,
+                    innerException.Message);
+            }
+
+            return newException;
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -88,8 +88,10 @@ namespace ArmaForces.ArmaServerManager
             .AddSingleton<IModDirectoryFinder, ModDirectoryFinder>()
             .AddSingleton<IApiModsetClient, ApiModsetClient>()
             .AddSingleton<ISteamClient, SteamClient>()
+            .AddSingleton<IManifestDownloader, ManifestDownloader>()
             .AddSingleton<IContentDownloader, ContentDownloader>()
             .AddSingleton<IContentVerifier, ContentVerifier>()
+            .AddSingleton<IContentFileVerifier, ContentFileVerifier>()
             .AddSingleton<IModsetProvider, ModsetProvider>()
 
             // Mission


### PR DESCRIPTION
This will remove all redundant files which are in mod's directory as SteamKit can't remove e.g. old bikeys correctly.