### PR TITLE
Increase steamProtocolMaxDataSize in default server config

### DIFF
--- a/ArmaForces.Arma.Server/example_server.cfg
+++ b/ArmaForces.Arma.Server/example_server.cfg
@@ -11,6 +11,8 @@ headlessClients[] = {127.0.0.1};
 localClient[] = {127.0.0.1};
 logFile = "";
 
+steamProtocolMaxDataSize = 8192; // Limit for maximum Steam Query packet length. Used by launcher to determine running mods.
+
 // JOINING RULES
 maxPlayers = 128; // The maximum number of players that can connect to server. The final number will be lesser between number given here and number of mission slots (default value is 64 for dedicated server).
 kickduplicate = 1; // Do not allow duplicate game IDs. Second player with an existing ID will be kicked automatically. 1 means active, 0 disabled.


### PR DESCRIPTION
- title

>Limit for maximum Steam Query packet length. (since Arma 3 v2.00)Increasing this value is dangerous as it can cause Arma server to send UDP packets of a size larger than the MTU. This will cause UDP packets to be fragmented which is not supported by some older routers.But increasing this will fix the modlist length limit in Arma 3 Launcher.