### PR TITLE
Fail job when failure Result is retured

### DIFF
--- a/ArmaForces.ArmaServerManager/Features/Hangfire/Exceptions/JobFailedException.cs
+++ b/ArmaForces.ArmaServerManager/Features/Hangfire/Exceptions/JobFailedException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ArmaForces.ArmaServerManager.Features.Hangfire.Exceptions
+{
+    /// <summary>
+    /// Used for failing hangfire jobs.
+    /// </summary>
+    public class JobFailedException : Exception
+    {
+        public JobFailedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/Features/Hangfire/Filters/FailOnResultFailureAttribute.cs
+++ b/ArmaForces.ArmaServerManager/Features/Hangfire/Filters/FailOnResultFailureAttribute.cs
@@ -1,0 +1,35 @@
+﻿using ArmaForces.ArmaServerManager.Features.Hangfire.Exceptions;
+using CSharpFunctionalExtensions;
+using Hangfire.Common;
+using Hangfire.States;
+
+namespace ArmaForces.ArmaServerManager.Features.Hangfire.Filters
+{
+    /// <summary>
+    /// Moves job to failed state when failure <see cref="Result{T}"/> is returned.
+    /// </summary>
+    public class FailOnResultFailureAttribute : JobFilterAttribute, IElectStateFilter
+    {
+        /// <inheritdoc />
+        public void OnStateElection(ElectStateContext context)
+        {
+            var contextCandidateState = context.CandidateState as SucceededState;
+            if (contextCandidateState?.Result is Result result)
+            {
+                result.OnFailure(error => SetFailedState(context, error));
+            }
+        }
+
+        /// <summary>
+        /// Sets job status to <see cref="FailedState"/>.
+        /// Creates new <see cref="JobFailedException"/> with <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="context">Job context.</param>
+        /// <param name="error">Error message for failed state.</param>
+        private static void SetFailedState(ElectStateContext context, string error)
+        {
+            var jobFailedException = new JobFailedException(error);
+            context.CandidateState = new FailedState(jobFailedException);
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -8,6 +8,7 @@ using ArmaForces.Arma.Server.Providers.Configuration;
 using ArmaForces.Arma.Server.Providers.Keys;
 using ArmaForces.ArmaServerManager.Features.Configuration;
 using ArmaForces.ArmaServerManager.Features.Hangfire;
+using ArmaForces.ArmaServerManager.Features.Hangfire.Filters;
 using ArmaForces.ArmaServerManager.Features.Hangfire.Helpers;
 using ArmaForces.ArmaServerManager.Features.Missions;
 using ArmaForces.ArmaServerManager.Features.Mods;
@@ -61,14 +62,16 @@ namespace ArmaForces.ArmaServerManager
                 .AddJsonOptions(opt => opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
             // Add Hangfire services.
-            services.AddHangfire(configuration => configuration
+            services.AddHangfire((provider, configuration) => configuration
                 .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
                 .UseSimpleAssemblyNameTypeSerializer()
                 .UseRecommendedSerializerSettings()
+                .UseFilter(provider.GetService<FailOnResultFailureAttribute>())
                 .UseLiteDbStorage(Configuration.GetConnectionString("HangfireConnection")))
 
             // Add the processing server as IHostedService
             .AddHangfireServer(ConfigureHangfireServer())
+            .AddTransient<FailOnResultFailureAttribute>()
 
             .AddHostedService<StartupService>()
 


### PR DESCRIPTION
If failed `Result` was returned, the job still succeeded. This PR converts failed results to failed job state.