### PR TITLE
Add support for external keys directory for mods

### DIFF
--- a/ArmaForces.Arma.Server.Tests/ArmaForces.Arma.Server.Tests.csproj
+++ b/ArmaForces.Arma.Server.Tests/ArmaForces.Arma.Server.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.19" />

--- a/ArmaForces.Arma.Server.Tests/Features/Keys/Finder/KeysFinderUnitTests.cs
+++ b/ArmaForces.Arma.Server.Tests/Features/Keys/Finder/KeysFinderUnitTests.cs
@@ -1,0 +1,144 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using ArmaForces.Arma.Server.Features.Keys.Finder;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using ArmaForces.Arma.Server.Features.Keys.Models;
+using AutoFixture;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace ArmaForces.Arma.Server.Tests.Features.Keys.Finder
+{
+    public class KeysFinderUnitTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+        private readonly string _workingDirectory;
+
+        public KeysFinderUnitTests()
+        {
+            _workingDirectory = _fixture.Create<string>();
+        }
+        
+        [Fact, Trait("Category", "Unit")]
+        public void GetKeysFromDirectory_NoKeys_ReturnsEmptyList()
+        {
+            var mockedFileSystem = CreateMockedFileSystem(_workingDirectory);
+            CreateRandomFileInDirectory(mockedFileSystem, _workingDirectory);
+
+            var keysFinder = CreateKeysFinder(mockedFileSystem);
+
+            var keysFromDirectory = keysFinder.GetKeysFromDirectory(_workingDirectory);
+
+            keysFromDirectory.Should().BeEmpty();
+        }
+        
+        [Fact, Trait("Category", "Unit")]
+        public void GetKeysFromDirectory_OneKeyIncluded_ReturnsListWithOneKey()
+        {
+            var mockedFileSystem = CreateMockedFileSystem(_workingDirectory);
+            CreateRandomFileInDirectory(mockedFileSystem, _workingDirectory);
+            
+            var bikeyFiles = CreateBikeyFilesInFileSystem(mockedFileSystem, _workingDirectory);
+
+            var keysFinder = CreateKeysFinder(mockedFileSystem);
+
+            var keysFromDirectory = keysFinder.GetKeysFromDirectory(_workingDirectory);
+
+            using (new AssertionScope())
+            {
+                keysFromDirectory.Should().HaveCount(1);
+                keysFromDirectory.Should().BeEquivalentTo(bikeyFiles);
+            }
+        }
+        
+        [Fact, Trait("Category", "Unit")]
+        public void GetKeysFromDirectory_MultipleKeysInSubfolders_ReturnsAllKeys()
+        {
+            var mockedFileSystem = CreateMockedFileSystem(_workingDirectory);
+            CreateRandomFileInDirectory(mockedFileSystem, _workingDirectory);
+            
+            var subDirectory = mockedFileSystem.Path.Join(_workingDirectory, _fixture.Create<string>());
+            var expectedBikeyFiles = CreateBikeyFilesInFileSystem(
+                mockedFileSystem,
+                subDirectory,
+                count: 5);
+
+            var keysFinder = CreateKeysFinder(mockedFileSystem);
+
+            var keysFromDirectory = keysFinder.GetKeysFromDirectory(_workingDirectory);
+
+            keysFromDirectory.Should().BeEquivalentTo(expectedBikeyFiles);
+        }
+
+        private static IFileSystem CreateMockedFileSystem(params string[] directories)
+        {
+            var mockFileSystem = new MockFileSystem();
+            
+            foreach (var directory in directories)
+            {
+                mockFileSystem.Directory.CreateDirectory(directory);
+            }
+
+            return mockFileSystem;
+        }
+
+        private List<BikeyFile> CreateBikeyFilesInFileSystem(
+            IFileSystem fileSystem,
+            string directory,
+            int count = 1)
+        {
+            return _fixture.CreateMany<string>(count)
+                .Select(fileName => CreateBikeyFileInFileSystem(fileSystem, directory, fileName))
+                .ToList();
+        }
+
+        private static BikeyFile CreateBikeyFileInFileSystem(
+            IFileSystem fileSystem,
+            string directory,
+            string fileName,
+            string fileExtension = "bikey")
+        {
+            var drive = MockUnixSupport.Path("C:\\");
+            var fileNameWithExtension = $"{fileName}.{fileExtension}";
+            var filePath = fileSystem.Path.Join(drive, directory, fileNameWithExtension);
+
+            var bikeyFile = new BikeyFile(filePath);
+            CreateFileInFileSystem(fileSystem, filePath);
+
+            return bikeyFile;
+        }
+
+        private void CreateRandomFileInDirectory(IFileSystem fileSystem, string directory)
+        {
+            var filePath = Path.Join(directory, _fixture.Create<string>());
+            CreateFileInFileSystem(fileSystem, filePath);
+        }
+
+        private static void CreateFileInFileSystem(IFileSystem fileSystem, string filePath)
+        {
+            var separator = MockUnixSupport.Path("\\");
+            
+            var directory = filePath
+                .Split(separator)
+                .SkipLast(1)
+                .Aggregate((x, y) => $"{x}{separator}{y}");
+            
+            if (!fileSystem.Directory.Exists(directory))
+            {
+                fileSystem.Directory.CreateDirectory(directory);
+            }
+            
+            fileSystem.File.Create(filePath);
+        }
+
+        private static IKeysFinder CreateKeysFinder(IFileSystem fileSystem)
+        {
+            var logger = new NullLogger<KeysFinder>();
+            return new KeysFinder(logger, fileSystem);
+        }
+    }
+}

--- a/ArmaForces.Arma.Server.Tests/Features/Keys/Finder/KeysFinderUnitTests.cs
+++ b/ArmaForces.Arma.Server.Tests/Features/Keys/Finder/KeysFinderUnitTests.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using ArmaForces.Arma.Server.Features.Keys.Models;
+using ArmaForces.Arma.Server.Tests.Helpers;
+using ArmaForces.Arma.Server.Tests.Helpers.Extensions;
 using AutoFixture;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -92,47 +94,14 @@ namespace ArmaForces.Arma.Server.Tests.Features.Keys.Finder
             int count = 1)
         {
             return _fixture.CreateMany<string>(count)
-                .Select(fileName => CreateBikeyFileInFileSystem(fileSystem, directory, fileName))
+                .Select(fileName => fileSystem.CreateBikeyFileInFileSystem(directory, fileName))
                 .ToList();
-        }
-
-        private static BikeyFile CreateBikeyFileInFileSystem(
-            IFileSystem fileSystem,
-            string directory,
-            string fileName,
-            string fileExtension = "bikey")
-        {
-            var drive = MockUnixSupport.Path("C:\\");
-            var fileNameWithExtension = $"{fileName}.{fileExtension}";
-            var filePath = fileSystem.Path.Join(drive, directory, fileNameWithExtension);
-
-            var bikeyFile = new BikeyFile(filePath);
-            CreateFileInFileSystem(fileSystem, filePath);
-
-            return bikeyFile;
         }
 
         private void CreateRandomFileInDirectory(IFileSystem fileSystem, string directory)
         {
-            var filePath = Path.Join(directory, _fixture.Create<string>());
-            CreateFileInFileSystem(fileSystem, filePath);
-        }
-
-        private static void CreateFileInFileSystem(IFileSystem fileSystem, string filePath)
-        {
-            var separator = MockUnixSupport.Path("\\");
-            
-            var directory = filePath
-                .Split(separator)
-                .SkipLast(1)
-                .Aggregate((x, y) => $"{x}{separator}{y}");
-            
-            if (!fileSystem.Directory.Exists(directory))
-            {
-                fileSystem.Directory.CreateDirectory(directory);
-            }
-            
-            fileSystem.File.Create(filePath);
+            var filePath = Path.Join(directory, _fixture.CreateFileName());
+            fileSystem.CreateFileInFileSystem(filePath);
         }
 
         private static IKeysFinder CreateKeysFinder(IFileSystem fileSystem)

--- a/ArmaForces.Arma.Server.Tests/Features/Keys/KeysPreparerIntegrationTests.cs
+++ b/ArmaForces.Arma.Server.Tests/Features/Keys/KeysPreparerIntegrationTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using ArmaForces.Arma.Server.Config;
+using ArmaForces.Arma.Server.Constants;
+using ArmaForces.Arma.Server.Extensions;
+using ArmaForces.Arma.Server.Features.Keys;
+using ArmaForces.Arma.Server.Features.Keys.Models;
+using ArmaForces.Arma.Server.Features.Mods;
+using ArmaForces.Arma.Server.Features.Modsets;
+using ArmaForces.Arma.Server.Tests.Helpers;
+using ArmaForces.Arma.Server.Tests.Helpers.Extensions;
+using AutoFixture;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace ArmaForces.Arma.Server.Tests.Features.Keys
+{
+    public class KeysPreparerIntegrationTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+        
+        [Fact, Trait("Category", "Integration")]
+        public void PrepareKeysForModset_MultipleModTypesAllWithBikeys_CorrectBikeysCopied()
+        {
+            var settings = new TestSettings();
+            var fileSystem = CreateFileSystemMock(settings);
+            var keysDirectory = MockUnixSupport.Path($"{settings.ServerDirectory}\\{KeysConstants.KeysDirectoryName}");
+            var modsDirectory = settings.ModsDirectory!;
+
+            var config = new ServerConfig(settings, fileSystem);
+            var modset = ModsetHelpers.CreateTestModset(_fixture, modsDirectory);
+            foreach (var mod in modset.Mods)
+            {
+                CreateDirectoryForMod(fileSystem, mod);
+            }
+
+            var serviceProvider = CreateServiceProvider(settings, config, fileSystem);
+
+            var keysPreparer = serviceProvider.GetService<IKeysPreparer>()!;
+
+            var result = keysPreparer.PrepareKeysForModset(modset);
+
+            using (new AssertionScope())
+            {
+                result.ShouldBeSuccess();
+                if (result.IsFailure)
+                {
+                    result.Error.Should().BeNullOrEmpty();
+                }
+                
+                var expectedBikeyNames = GetBikeysForMods(fileSystem, modset.ClientLoadableMods)
+                    .Append(new BikeyFile("a3.bikey"))
+                    .Select(x => x.FileName)
+                    .ToList();
+
+                var copiedBikeys = GetCopiedBikeys(fileSystem, keysDirectory)
+                    .Select(x => x.FileName)
+                    .ToList();
+
+                copiedBikeys.Should().BeEquivalentTo(expectedBikeyNames);
+            }
+        }
+
+        [Fact, Trait("Category", "Integration")]
+        public void PrepareKeysForModset_SingleModWithoutKeyWithExternalKey_ExternalBikeyCopied()
+        {
+            var settings = new TestSettings();
+            var fileSystem = CreateFileSystemMock(settings);
+            var keysDirectory = MockUnixSupport.Path($"{settings.ServerDirectory}\\{KeysConstants.KeysDirectoryName}");
+            var modsDirectory = settings.ModsDirectory!;
+            var externalKeysDirectory = MockUnixSupport.Path($"{settings.ServerConfigDirectory}\\{KeysConstants.KeysDirectoryName}");
+
+            var config = new ServerConfig(settings, fileSystem);
+            var mod = ModHelpers.CreateTestMod(
+                _fixture,
+                ModType.Required,
+                modsDirectory);
+            CreateDirectoryForMod(fileSystem, mod, createBikey: false);
+            
+            var modset = ModsetHelpers.CreateModsetWithMods(_fixture, mod.AsList());
+            CreateExternalKeyForMod(fileSystem, externalKeysDirectory, mod);
+
+            var serviceProvider = CreateServiceProvider(settings, config, fileSystem);
+
+            var keysPreparer = serviceProvider.GetService<IKeysPreparer>()!;
+
+            var result = keysPreparer.PrepareKeysForModset(modset);
+
+            using (new AssertionScope())
+            {
+                result.ShouldBeSuccess();
+                if (result.IsFailure)
+                {
+                    result.Error.Should().BeNullOrEmpty();
+                }
+                
+                var expectedBikeyNames = new List<BikeyFile>
+                {
+                    new BikeyFile("a3.bikey"),
+                    new BikeyFile($"{mod.Name}{KeysConstants.KeyExtension}")
+                }
+                    .Select(x => x.FileName)
+                    .ToList();
+
+                var copiedBikeys = GetCopiedBikeys(fileSystem, keysDirectory)
+                    .Select(x => x.FileName)
+                    .ToList();
+
+                copiedBikeys.Should().BeEquivalentTo(expectedBikeyNames);
+            }
+        }
+
+        private static void CreateExternalKeyForMod(
+            IFileSystem fileSystem,
+            string externalKeysDirectory,
+            IMod mod)
+        {
+            var externalKeysDirectoryForMod = fileSystem.Path.Join(externalKeysDirectory, mod.Directory!.Split("\\").Last());
+            fileSystem.Directory.CreateDirectory(externalKeysDirectoryForMod);
+
+            var keyFileName = $"{mod.Name}{KeysConstants.KeyExtension}";
+            fileSystem.File.Create(fileSystem.Path.Join(externalKeysDirectoryForMod, keyFileName));
+        }
+
+        private IFileSystem CreateFileSystemMock(ISettings settings)
+        {
+            var fileSystemMock = new MockFileSystem();
+
+            fileSystemMock.Directory.CreateDirectory(settings.ManagerDirectory);
+            fileSystemMock.File.Create(fileSystemMock.Path.Join(settings.ManagerDirectory, KeysConstants.ArmaKey));
+            
+            fileSystemMock.Directory.CreateDirectory(settings.ServerDirectory);
+            fileSystemMock.Directory.CreateDirectory(settings.ModsDirectory);
+            fileSystemMock.Directory.CreateDirectory(
+                fileSystemMock.Path.Join(settings.ServerDirectory, KeysConstants.KeysDirectoryName));
+
+            return fileSystemMock;
+        }
+
+        private List<BikeyFile> GetCopiedBikeys(
+            IFileSystem fileSystem,
+            string keysDirectory)
+        {
+            return fileSystem.Directory.GetFiles(keysDirectory)
+                .Select(path => new BikeyFile(path))
+                .ToList();
+        }
+
+        private List<BikeyFile> GetBikeysForMods(IFileSystem fileSystem, ISet<IMod> mods)
+        {
+            return mods
+                .Select(mod => fileSystem.Directory.GetFiles(
+                    mod.Directory,
+                    $"*{KeysConstants.KeyExtension}",
+                    SearchOption.AllDirectories))
+                .SelectMany(x => x)
+                .Select(x => new BikeyFile(x))
+                .ToList();
+        }
+
+        private void CreateDirectoryForMod(
+            IFileSystem fileSystem,
+            IMod mod,
+            bool createBikey = true)
+        {
+            var modDirectoryPath = mod.Directory;
+            fileSystem.Directory.CreateDirectory(modDirectoryPath);
+            
+            var modKeysPath = fileSystem.Path.Join(modDirectoryPath, KeysConstants.KeysDirectoryName);
+            fileSystem.Directory.CreateDirectory(modKeysPath);
+
+            if (createBikey)
+            {
+                var bikeyFilePath = fileSystem.Path.Join(
+                    modKeysPath,
+                    $"{_fixture.Create<string>()}{KeysConstants.KeyExtension}");
+                fileSystem.File.Create(bikeyFilePath);
+            }
+        }
+
+        private static IServiceProvider CreateServiceProvider(
+            ISettings settings,
+            IConfig config,
+            IFileSystem fileSystem)
+        {
+            return new ServiceCollection()
+                .AddLogging()
+                .AddArmaServer()
+                .Replace(new ServiceDescriptor(typeof(ISettings), settings))
+                .Replace(new ServiceDescriptor(typeof(IConfig), config))
+                .AddSingleton(fileSystem)
+                .BuildServiceProvider();
+        }
+    }
+}

--- a/ArmaForces.Arma.Server.Tests/Features/Keys/KeysPreparerIntegrationTests.cs
+++ b/ArmaForces.Arma.Server.Tests/Features/Keys/KeysPreparerIntegrationTests.cs
@@ -39,7 +39,7 @@ namespace ArmaForces.Arma.Server.Tests.Features.Keys
             _serviceProvider = CreateServiceProvider(_settings, config, _fileSystem);
 
             _keysDirectory = MockUnixSupport.Path($"{_settings.ServerDirectory}\\{KeysConstants.KeysDirectoryName}");
-            _externalKeysDirectory = MockUnixSupport.Path($"{_settings.ServerConfigDirectory}\\{KeysConstants.KeysDirectoryName}");
+            _externalKeysDirectory = MockUnixSupport.Path($"{_settings.ServerConfigDirectory}\\{KeysConstants.ExternalKeysDirectoryName}");
             _modsDirectory = _settings.ModsDirectory!;
         }
         

--- a/ArmaForces.Arma.Server.Tests/Features/Servers/DedicatedServerTests.cs
+++ b/ArmaForces.Arma.Server.Tests/Features/Servers/DedicatedServerTests.cs
@@ -5,11 +5,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Config;
 using ArmaForces.Arma.Server.Exceptions;
+using ArmaForces.Arma.Server.Features.Keys;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.Arma.Server.Features.Processes;
 using ArmaForces.Arma.Server.Features.Servers;
 using ArmaForces.Arma.Server.Features.Servers.DTOs;
-using ArmaForces.Arma.Server.Providers.Keys;
 using ArmaForces.Arma.Server.Tests.Helpers;
 using AutoFixture;
 using CSharpFunctionalExtensions;
@@ -27,7 +27,7 @@ namespace ArmaForces.Arma.Server.Tests.Features.Servers
         private const int ServerPort = 2302;
 
         private readonly Mock<IModsetConfig> _modsetConfigMock = new Mock<IModsetConfig>();
-        private readonly Mock<IKeysProvider> _keysProviderMock = new Mock<IKeysProvider>();
+        private readonly Mock<IKeysPreparer> _keysProviderMock = new Mock<IKeysPreparer>();
         private readonly Mock<IArmaProcessManager> _armaProcessManagerMock = new Mock<IArmaProcessManager>();
         private readonly IModset _modset;
 

--- a/ArmaForces.Arma.Server.Tests/Helpers/Extensions/FixtureExtensions.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/Extensions/FixtureExtensions.cs
@@ -1,0 +1,13 @@
+﻿using AutoFixture;
+
+namespace ArmaForces.Arma.Server.Tests.Helpers.Extensions
+{
+    public static class FixtureExtensions
+    {
+        public static string CreateFileName(this Fixture fixture)
+            => CreateFileName(fixture, fixture.Create<string>());
+
+        public static string CreateFileName(this Fixture fixture, string extension)
+            => fixture.Create<string>() + (extension.StartsWith('.') ? extension : '.' + extension);
+    }
+}

--- a/ArmaForces.Arma.Server.Tests/Helpers/Extensions/ResultExtensions.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/Extensions/ResultExtensions.cs
@@ -1,0 +1,19 @@
+﻿using CSharpFunctionalExtensions;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace ArmaForces.Arma.Server.Tests.Helpers.Extensions
+{
+    public static class ResultExtensions
+    {
+        public static AndConstraint<BooleanAssertions> ShouldBeSuccess(this Result result)
+        {
+            return result.IsSuccess.Should().BeTrue();
+        }
+
+        public static AndConstraint<BooleanAssertions> ShouldBeFailure(this Result result)
+        {
+            return result.IsFailure.Should().BeTrue();
+        }
+    }
+}

--- a/ArmaForces.Arma.Server.Tests/Helpers/MockedFileSystemHelpers.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/MockedFileSystemHelpers.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace ArmaForces.Arma.Server.Tests.Helpers
 {
-    public class MockedFileSystemHelpers
+    public static class MockedFileSystemHelpers
     {
         public static void CopyExampleFilesToMockedFileSystem(IFileSystem fileSystemMock, string? baseDirectory = null)
         {

--- a/ArmaForces.Arma.Server.Tests/Helpers/MockedFileSystemHelpers.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/MockedFileSystemHelpers.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using ArmaForces.Arma.Server.Features.Keys.Models;
 
 namespace ArmaForces.Arma.Server.Tests.Helpers
 {
@@ -47,6 +49,41 @@ namespace ArmaForces.Arma.Server.Tests.Helpers
             var fileName = Path.GetFileName(filePath);
             mockedFilePath ??= Path.Join(baseDirectory, fileName);
             fileSystemMock.File.WriteAllText(mockedFilePath, content);
+        }
+        
+        public static BikeyFile CreateBikeyFileInFileSystem(
+            this IFileSystem fileSystem,
+            string directory,
+            string fileName,
+            string fileExtension = "bikey")
+        {
+            var fileNameWithExtension = fileSystem.Path.HasExtension(fileName) 
+                ? fileName
+                : $"{fileName}.{fileExtension}";
+            var filePath = fileSystem.Path.GetFullPath( 
+                fileSystem.Path.Join(directory, fileNameWithExtension));
+            
+            var bikeyFile = new BikeyFile(filePath);
+            fileSystem.CreateFileInFileSystem(filePath);
+
+            return bikeyFile;
+        }
+        
+        public static void CreateFileInFileSystem(this IFileSystem fileSystem, string filePath)
+        {
+            var separator = fileSystem.Path.DirectorySeparatorChar;
+            
+            var directory = filePath
+                .Split(separator)
+                .SkipLast(1)
+                .Aggregate((x, y) => $"{x}{separator}{y}");
+            
+            if (!fileSystem.Directory.Exists(directory))
+            {
+                fileSystem.Directory.CreateDirectory(directory);
+            }
+            
+            fileSystem.File.Create(filePath);
         }
     }
 }

--- a/ArmaForces.Arma.Server.Tests/Helpers/ModHelpers.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/ModHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using ArmaForces.Arma.Server.Features.Mods;
 using AutoFixture;
 
@@ -11,15 +12,20 @@ namespace ArmaForces.Arma.Server.Tests.Helpers
         {
             return fixture.Create<Mod>();
         }
-
-        public static Mod CreateTestMod(Fixture fixture, ModType modType)
+       
+        public static Mod CreateTestMod(
+            Fixture fixture,
+            ModType modType,
+            string? modBaseDirectory = null)
         {
+            var modName = fixture.Create<string>();
+            
             return new Mod
             {
                 CreatedAt = fixture.Create<DateTime>(),
-                Directory = fixture.Create<string>(),
+                Directory = Path.Join(modBaseDirectory, modName),
                 LastUpdatedAt = fixture.Create<DateTime>(),
-                Name = fixture.Create<string>(),
+                Name = modName,
                 Source = fixture.Create<ModSource>(),
                 Type = modType,
                 WebId = fixture.Create<string>(),

--- a/ArmaForces.Arma.Server.Tests/Helpers/ModsetHelpers.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/ModsetHelpers.cs
@@ -9,9 +9,23 @@ namespace ArmaForces.Arma.Server.Tests.Helpers
 {
     public static class ModsetHelpers
     {
-        public static Modset CreateEmptyModset(Fixture fixture) => CreateTestModset(fixture, 0);
+        public static Modset CreateEmptyModset(Fixture fixture) => CreateTestModset(fixture, eachModTypeNumber: 0);
 
-        public static Modset CreateTestModset(Fixture fixture, int eachModTypeNumber = 5)
+        public static Modset CreateModsetWithMods(Fixture fixture, IReadOnlyCollection<IMod> mods)
+        {
+            return new Modset
+            {
+                Mods = mods.ToHashSet(),
+                LastUpdatedAt = fixture.Create<DateTime>(),
+                Name = fixture.Create<string>(),
+                WebId = fixture.Create<string>()
+            };
+        }
+        
+        public static Modset CreateTestModset(
+            Fixture fixture,
+            string? modsDirectory = null,
+            int eachModTypeNumber = 5)
         {
             var modset = new Modset
             {
@@ -23,10 +37,10 @@ namespace ArmaForces.Arma.Server.Tests.Helpers
 
             for (var i = 0; i < eachModTypeNumber; i++)
             {
-                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.ServerSide));
-                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.ClientSide));
-                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.Optional));
-                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.Required));
+                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.ServerSide, modsDirectory));
+                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.ClientSide, modsDirectory));
+                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.Optional, modsDirectory));
+                modset.Mods.Add(ModHelpers.CreateTestMod(fixture, ModType.Required, modsDirectory));
             }
 
             return modset;

--- a/ArmaForces.Arma.Server.Tests/Helpers/TestSettings.cs
+++ b/ArmaForces.Arma.Server.Tests/Helpers/TestSettings.cs
@@ -1,0 +1,29 @@
+﻿using System.IO.Abstractions.TestingHelpers;
+using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Config;
+using CSharpFunctionalExtensions;
+
+namespace ArmaForces.Arma.Server.Tests.Helpers
+{
+    public class TestSettings : ISettings
+    {
+        public string? ApiMissionsBaseUrl { get; set; }
+        public string? ApiModsetsBaseUrl { get; set; }
+        public string ManagerDirectory => MockUnixSupport.Path($"{ServerDirectory}\\Manager");
+        public string ModsetConfigDirectoryName { get; set; } = "ModsetConfig";
+        public string? ModsDirectory => MockUnixSupport.Path($"{ServerDirectory}\\Mods");
+        public string ModsManagerCacheFileName { get; set; } = string.Empty;
+        public string? ServerConfigDirectory => MockUnixSupport.Path($"{ServerDirectory}\\ServerConfig");
+        public string? ServerDirectory { get; set; } = MockUnixSupport.Path("C:\\Arma");
+        public string? ServerExecutable => MockUnixSupport.Path($"{ServerDirectory}\\{ServerExecutableName}");
+        public string ServerExecutableName { get; set; } = "arma3.exe";
+        public string? SteamUser { get; set; }
+        public string? SteamPassword { get; set; }
+        
+        public Result LoadSettings() => throw new System.NotImplementedException();
+
+        public Result ReloadSettings() => throw new System.NotImplementedException();
+
+        public async Task<Result> ReloadSettings(ISettings settings) => throw new System.NotImplementedException();
+    }
+}

--- a/ArmaForces.Arma.Server/Config/ConfigReplacer.cs
+++ b/ArmaForces.Arma.Server/Config/ConfigReplacer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 

--- a/ArmaForces.Arma.Server/Config/ModsetConfig.cs
+++ b/ArmaForces.Arma.Server/Config/ModsetConfig.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;

--- a/ArmaForces.Arma.Server/Config/Settings.cs
+++ b/ArmaForces.Arma.Server/Config/Settings.cs
@@ -18,6 +18,7 @@ namespace ArmaForces.Arma.Server.Config
         public string? ApiMissionsBaseUrl { get; set; }
         public string? ApiModsetsBaseUrl { get; set; }
         public string ModsetConfigDirectoryName { get; set; } = "modsetConfig";
+        // TODO: Extract to IModsConfig or something
         public string? ModsDirectory { get; set; }
         public string ModsManagerCacheFileName { get; set; } = ".ManagerModsCache";
         public string? ServerConfigDirectory { get; set; }

--- a/ArmaForces.Arma.Server/Constants/KeysConstants.cs
+++ b/ArmaForces.Arma.Server/Constants/KeysConstants.cs
@@ -3,6 +3,8 @@
     internal static class KeysConstants
     {
         public const string KeysDirectoryName = "Keys";
+
+        public const string ExternalKeysDirectoryName = "External" + KeysDirectoryName;
         
         public const string KeyExtension = ".bikey";
 

--- a/ArmaForces.Arma.Server/Constants/KeysConstants.cs
+++ b/ArmaForces.Arma.Server/Constants/KeysConstants.cs
@@ -6,6 +6,8 @@
         
         public const string KeyExtension = ".bikey";
 
-        public static string ArmaKey => $"a3{KeyExtension}";
+        public const string KeyExtensionSearchPattern = "*" + KeyExtension;
+
+        public const string ArmaKey = "a3" + KeyExtension;
     }
 }

--- a/ArmaForces.Arma.Server/Constants/KeysConstants.cs
+++ b/ArmaForces.Arma.Server/Constants/KeysConstants.cs
@@ -2,6 +2,8 @@
 {
     internal static class KeysConstants
     {
+        public const string KeysDirectoryName = "Keys";
+        
         public const string KeyExtension = ".bikey";
 
         public static string ArmaKey => $"a3{KeyExtension}";

--- a/ArmaForces.Arma.Server/Extensions/EnumerableExtensions.cs
+++ b/ArmaForces.Arma.Server/Extensions/EnumerableExtensions.cs
@@ -5,6 +5,14 @@ namespace ArmaForces.Arma.Server.Extensions
 {
     public static class EnumerableExtensions
     {
+        public static List<T> AsList<T>(this T item)
+        {
+            return new List<T>
+            {
+                item
+            };
+        }
+        
         public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> enumerable) where T : class
         {
             return enumerable

--- a/ArmaForces.Arma.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/ArmaForces.Arma.Server/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+﻿using ArmaForces.Arma.Server.Features.Keys;
+using ArmaForces.Arma.Server.Features.Keys.Finder;
+using ArmaForces.Arma.Server.Features.Keys.IO;
+using ArmaForces.Arma.Server.Features.Mods;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ArmaForces.Arma.Server.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddArmaServer(this IServiceCollection services)
+        {
+            return services
+                .AddKeys()
+                .AddMods();
+        }
+
+        private static IServiceCollection AddKeys(this IServiceCollection services)
+        {
+            return services
+                .AddScoped<IKeysPreparer, KeysPreparer>()
+                .AddScoped<IKeysFinder, KeysFinder>()
+                .AddScoped<IKeysCopier, KeysCopier>();
+        }
+
+        private static IServiceCollection AddMods(this IServiceCollection services)
+        {
+            return services
+                .AddScoped<IModDirectoryFinder, ModDirectoryFinder>();
+        }
+    }
+}

--- a/ArmaForces.Arma.Server/Features/Keys/Finder/IKeysFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Finder/IKeysFinder.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using ArmaForces.Arma.Server.Features.Keys.Models;
+
+namespace ArmaForces.Arma.Server.Features.Keys.Finder
+{
+    public interface IKeysFinder
+    {
+        List<BikeyFile> GetKeysFromDirectory(string? directory);
+    }
+}

--- a/ArmaForces.Arma.Server/Features/Keys/Finder/IKeysFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Finder/IKeysFinder.cs
@@ -3,7 +3,7 @@ using ArmaForces.Arma.Server.Features.Keys.Models;
 
 namespace ArmaForces.Arma.Server.Features.Keys.Finder
 {
-    public interface IKeysFinder
+    internal interface IKeysFinder
     {
         List<BikeyFile> GetKeysFromDirectory(string? directory);
     }

--- a/ArmaForces.Arma.Server/Features/Keys/Finder/KeysFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Finder/KeysFinder.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using ArmaForces.Arma.Server.Constants;
+using ArmaForces.Arma.Server.Features.Keys.Models;
+using Microsoft.Extensions.Logging;
+
+namespace ArmaForces.Arma.Server.Features.Keys.Finder
+{
+    public class KeysFinder : IKeysFinder
+    {
+        private readonly ILogger<KeysFinder> _logger;
+        private readonly IFileSystem _fileSystem;
+
+        public KeysFinder(ILogger<KeysFinder> logger, IFileSystem? fileSystem = null)
+        {
+            _logger = logger;
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public List<BikeyFile> GetKeysFromDirectory(string? directory)
+        {
+            _logger.LogTrace("Looking for keys in {directory}.", directory);
+
+            var keyFiles = directory is null
+                ? new string[0]
+                : _fileSystem.Directory.GetFiles(
+                    directory,
+                    $"*{KeysConstants.KeyExtension}",
+                    SearchOption.AllDirectories);
+
+            if (keyFiles.Any())
+            {
+                _logger.LogDebug(
+                    "Found {count} keys in {directory}.",
+                    keyFiles.Length,
+                    directory);
+            }
+            else
+            {
+                _logger.LogDebug("No keys found in {directory}.", directory);
+            }
+
+            return keyFiles
+                .Select(path => new BikeyFile(path))
+                .ToList();
+        }
+    }
+}

--- a/ArmaForces.Arma.Server/Features/Keys/Finder/KeysFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Finder/KeysFinder.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmaForces.Arma.Server.Features.Keys.Finder
 {
-    public class KeysFinder : IKeysFinder
+    internal class KeysFinder : IKeysFinder
     {
         private readonly ILogger<KeysFinder> _logger;
         private readonly IFileSystem _fileSystem;

--- a/ArmaForces.Arma.Server/Features/Keys/Finder/KeysFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Finder/KeysFinder.cs
@@ -27,7 +27,7 @@ namespace ArmaForces.Arma.Server.Features.Keys.Finder
                 ? new string[0]
                 : _fileSystem.Directory.GetFiles(
                     directory,
-                    $"*{KeysConstants.KeyExtension}",
+                    KeysConstants.KeyExtensionSearchPattern,
                     SearchOption.AllDirectories);
 
             if (keyFiles.Any())

--- a/ArmaForces.Arma.Server/Features/Keys/IKeysPreparer.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/IKeysPreparer.cs
@@ -1,9 +1,9 @@
 ﻿using ArmaForces.Arma.Server.Features.Modsets;
 using CSharpFunctionalExtensions;
 
-namespace ArmaForces.Arma.Server.Providers.Keys
+namespace ArmaForces.Arma.Server.Features.Keys
 {
-    public interface IKeysProvider
+    public interface IKeysPreparer
     {
         Result PrepareKeysForModset(IModset modset);
     }

--- a/ArmaForces.Arma.Server/Features/Keys/IO/IKeysCopier.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/IO/IKeysCopier.cs
@@ -4,7 +4,7 @@ using CSharpFunctionalExtensions;
 
 namespace ArmaForces.Arma.Server.Features.Keys.IO
 {
-    public interface IKeysCopier
+    internal interface IKeysCopier
     {
         Result DeleteKeys(IReadOnlyCollection<BikeyFile> bikeyFiles);
         Result CopyKeys(string targetDirectory, IReadOnlyCollection<BikeyFile> bikeyFiles);

--- a/ArmaForces.Arma.Server/Features/Keys/IO/IKeysCopier.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/IO/IKeysCopier.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using ArmaForces.Arma.Server.Features.Keys.Models;
+using CSharpFunctionalExtensions;
+
+namespace ArmaForces.Arma.Server.Features.Keys.IO
+{
+    public interface IKeysCopier
+    {
+        Result DeleteKeys(IReadOnlyCollection<BikeyFile> bikeyFiles);
+        Result CopyKeys(string targetDirectory, IReadOnlyCollection<BikeyFile> bikeyFiles);
+    }
+}

--- a/ArmaForces.Arma.Server/Features/Keys/IO/KeysCopier.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/IO/KeysCopier.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using ArmaForces.Arma.Server.Features.Keys.Models;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
+
+namespace ArmaForces.Arma.Server.Features.Keys.IO
+{
+    public class KeysCopier : IKeysCopier
+    {
+        private readonly ILogger<KeysCopier> _logger;
+        private readonly IFileSystem _fileSystem;
+
+        public KeysCopier(ILogger<KeysCopier> logger, IFileSystem? fileSystem = null)
+        {
+            _logger = logger;
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public Result DeleteKeys(IReadOnlyCollection<BikeyFile> bikeyFiles)
+        {
+            foreach (var bikeyFile in bikeyFiles)
+            {
+                _logger.LogTrace("Removing {keyName} key.", _fileSystem.Path.GetFileName(bikeyFile.Path));
+                
+                _fileSystem.File.Delete(bikeyFile.Path);
+            }
+
+            return Result.Success();
+        }
+
+        public Result CopyKeys(string targetDirectory, IReadOnlyCollection<BikeyFile> bikeyFiles)
+        {
+            if (!bikeyFiles.Any())
+            {
+                return Result.Failure("No keys found.");
+            }
+
+            foreach (var modBikey in bikeyFiles)
+            {
+                var keyName = _fileSystem.Path.GetFileName(modBikey.Path);
+                var destinationKeyPath = _fileSystem.Path.Join(targetDirectory, keyName);
+                
+                _logger.LogTrace("Copying {keyName}.", keyName);
+                
+                if (!_fileSystem.File.Exists(destinationKeyPath))
+                {
+                    _fileSystem.File.Copy(modBikey.Path, destinationKeyPath);
+                }
+            }
+
+            return Result.Success();
+        }
+    }
+}

--- a/ArmaForces.Arma.Server/Features/Keys/IO/KeysCopier.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/IO/KeysCopier.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmaForces.Arma.Server.Features.Keys.IO
 {
-    public class KeysCopier : IKeysCopier
+    internal class KeysCopier : IKeysCopier
     {
         private readonly ILogger<KeysCopier> _logger;
         private readonly IFileSystem _fileSystem;

--- a/ArmaForces.Arma.Server/Features/Keys/KeysPreparer.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/KeysPreparer.cs
@@ -25,7 +25,7 @@ namespace ArmaForces.Arma.Server.Features.Keys
 
         private readonly string _keysDirectory;
         private readonly string _managerDirectory;
-        private readonly string _serverConfigDirectoryPath;
+        private readonly string _externalKeysDirectoryPath;
 
         public KeysPreparer(
             ISettings settings,
@@ -43,7 +43,7 @@ namespace ArmaForces.Arma.Server.Features.Keys
             _fileSystem = fileSystem ?? new FileSystem();
 
             _keysDirectory = _fileSystem.Path.Join(settings.ServerDirectory, KeysConstants.KeysDirectoryName);
-            _serverConfigDirectoryPath = _fileSystem.Path.Join(serverConfig.DirectoryPath, KeysConstants.KeysDirectoryName);
+            _externalKeysDirectoryPath = _fileSystem.Path.Join(serverConfig.DirectoryPath, KeysConstants.ExternalKeysDirectoryName);
             _managerDirectory = settings.ManagerDirectory;
         }
 
@@ -117,7 +117,7 @@ namespace ArmaForces.Arma.Server.Features.Keys
         
         private IEnumerable<BikeyFile> GetExternalKeys(IMod mod)
         {
-            var modDirectoryResult = _modDirectoryFinder.TryFindModDirectory(mod, _serverConfigDirectoryPath);
+            var modDirectoryResult = _modDirectoryFinder.TryFindModDirectory(mod, _externalKeysDirectoryPath);
             
             return modDirectoryResult.IsSuccess
                 ? _keysFinder.GetKeysFromDirectory(modDirectoryResult.Value)

--- a/ArmaForces.Arma.Server/Features/Keys/KeysPreparer.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/KeysPreparer.cs
@@ -10,19 +10,19 @@ using ArmaForces.Arma.Server.Features.Modsets;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
-namespace ArmaForces.Arma.Server.Providers.Keys
+namespace ArmaForces.Arma.Server.Features.Keys
 {
-    public class KeysProvider : IKeysProvider
+    public class KeysPreparer : IKeysPreparer
     {
-        private readonly ILogger<KeysProvider> _logger;
+        private readonly ILogger<KeysPreparer> _logger;
         private readonly IFileSystem _fileSystem;
 
         private readonly string _keysDirectory;
         private readonly string _managerDirectory;
 
-        public KeysProvider(
+        public KeysPreparer(
             ISettings settings,
-            ILogger<KeysProvider> logger,
+            ILogger<KeysPreparer> logger,
             IFileSystem? fileSystem = null)
         {
             _logger = logger;

--- a/ArmaForces.Arma.Server/Features/Keys/Models/BikeyFile.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Models/BikeyFile.cs
@@ -21,6 +21,11 @@
         /// Path to bikey file.
         /// </summary>
         public string Path { get; }
+
+        /// <summary>
+        /// Bikey file name.
+        /// </summary>
+        public string FileName => System.IO.Path.GetFileName(Path);
         
         /// <summary>
         /// Indicates what the bikey is for.

--- a/ArmaForces.Arma.Server/Features/Keys/Models/BikeyFile.cs
+++ b/ArmaForces.Arma.Server/Features/Keys/Models/BikeyFile.cs
@@ -1,0 +1,30 @@
+﻿namespace ArmaForces.Arma.Server.Features.Keys.Models
+{
+    /// <summary>
+    /// Encapsulates basic bikey file information.
+    /// </summary>
+    public readonly struct BikeyFile
+    {
+        public BikeyFile(string path)
+        {
+            Path = path;
+            Target = "Unknown";
+        }
+        
+        public BikeyFile(string path, string target)
+        {
+            Path = path;
+            Target = target;
+        }
+
+        /// <summary>
+        /// Path to bikey file.
+        /// </summary>
+        public string Path { get; }
+        
+        /// <summary>
+        /// Indicates what the bikey is for.
+        /// </summary>
+        public string Target { get; }
+    }
+}

--- a/ArmaForces.Arma.Server/Features/Mods/IModDirectoryFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Mods/IModDirectoryFinder.cs
@@ -1,6 +1,4 @@
-﻿using ArmaForces.Arma.Server.Features.Mods;
-
-namespace ArmaForces.ArmaServerManager.Features.Mods
+﻿namespace ArmaForces.Arma.Server.Features.Mods
 {
     public interface IModDirectoryFinder
     {

--- a/ArmaForces.Arma.Server/Features/Mods/IModDirectoryFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Mods/IModDirectoryFinder.cs
@@ -1,9 +1,13 @@
-﻿namespace ArmaForces.Arma.Server.Features.Mods
+﻿using CSharpFunctionalExtensions;
+
+namespace ArmaForces.Arma.Server.Features.Mods
 {
     public interface IModDirectoryFinder
     {
         IMod CreateModFromDirectory(string directoryPath);
 
         IMod TryEnsureModDirectory(IMod mod);
+
+        Result<string> TryFindModDirectory(IMod mod, string directoryToSearch);
     }
 }

--- a/ArmaForces.Arma.Server/Features/Mods/ModDirectoryFinder.cs
+++ b/ArmaForces.Arma.Server/Features/Mods/ModDirectoryFinder.cs
@@ -3,13 +3,12 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using ArmaForces.Arma.Server.Config;
-using ArmaForces.Arma.Server.Features.Mods;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
-namespace ArmaForces.ArmaServerManager.Features.Mods
+namespace ArmaForces.Arma.Server.Features.Mods
 {
-    public class ModDirectoryFinder : IModDirectoryFinder
+    internal class ModDirectoryFinder : IModDirectoryFinder
     {
         private readonly ILogger<ModDirectoryFinder> _logger;
         private readonly IFileSystem _fileSystem;

--- a/ArmaForces.Arma.Server/Features/Processes/ArmaProcessManager.cs
+++ b/ArmaForces.Arma.Server/Features/Processes/ArmaProcessManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 

--- a/ArmaForces.Arma.Server/Features/Servers/DedicatedServer.cs
+++ b/ArmaForces.Arma.Server/Features/Servers/DedicatedServer.cs
@@ -6,10 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Config;
 using ArmaForces.Arma.Server.Exceptions;
+using ArmaForces.Arma.Server.Features.Keys;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.Arma.Server.Features.Processes;
 using ArmaForces.Arma.Server.Features.Servers.DTOs;
-using ArmaForces.Arma.Server.Providers.Keys;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
@@ -21,7 +21,7 @@ namespace ArmaForces.Arma.Server.Features.Servers
     {
         private readonly IModsetConfig _modsetConfig;
         private readonly ILogger<DedicatedServer> _logger;
-        private readonly IKeysProvider _keysProvider;
+        private readonly IKeysPreparer _keysPreparer;
         private readonly IArmaProcessManager _armaProcessManager;
 
         private readonly List<IArmaProcess> _headlessProcesses;
@@ -31,14 +31,14 @@ namespace ArmaForces.Arma.Server.Features.Servers
             int port,
             IModset modset,
             IModsetConfig modsetConfig,
-            IKeysProvider keysProvider,
+            IKeysPreparer keysPreparer,
             IArmaProcessManager armaProcessManager,
             IArmaProcess armaProcess,
             IEnumerable<IArmaProcess> headlessClients,
             ILogger<DedicatedServer> logger)
         {
             Port = port;
-            _keysProvider = keysProvider;
+            _keysPreparer = keysPreparer;
             _armaProcessManager = armaProcessManager;
             Modset = modset;
             _modsetConfig = modsetConfig;
@@ -68,7 +68,7 @@ namespace ArmaForces.Arma.Server.Features.Servers
             _logger.LogTrace("Starting server on port {port} with {modsetName} modset.", Port, Modset.Name);
 
             return _modsetConfig.CopyConfigFiles()
-                .Bind(() => _keysProvider.PrepareKeysForModset(Modset))
+                .Bind(() => _keysPreparer.PrepareKeysForModset(Modset))
                 .Bind(() => _armaProcess.Start())
                 .Tap(() => _armaProcess.OnProcessShutdown += OnServerProcessShutdown)
                 .Bind(() => _headlessProcesses.Select(x => x.Start())

--- a/ArmaForces.Arma.Server/Features/Servers/ServerBuilder.cs
+++ b/ArmaForces.Arma.Server/Features/Servers/ServerBuilder.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using ArmaForces.Arma.Server.Features.Keys;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.Arma.Server.Features.Processes;
 using ArmaForces.Arma.Server.Features.Servers.Exceptions;
 using ArmaForces.Arma.Server.Providers.Configuration;
-using ArmaForces.Arma.Server.Providers.Keys;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
@@ -12,7 +12,7 @@ namespace ArmaForces.Arma.Server.Features.Servers
 {
     public class ServerBuilder : IServerBuilder
     {
-        private readonly IKeysProvider _keysProvider;
+        private readonly IKeysPreparer _keysPreparer;
         private readonly IServerConfigurationProvider _serverConfigurationProvider;
         private readonly IArmaProcessManager _armaProcessManager;
         private readonly IArmaProcessFactory _armaProcessFactory;
@@ -26,13 +26,13 @@ namespace ArmaForces.Arma.Server.Features.Servers
         private IReadOnlyList<IArmaProcess>? _headlessClients;
 
         public ServerBuilder(
-            IKeysProvider keysProvider,
+            IKeysPreparer keysPreparer,
             IServerConfigurationProvider serverConfigurationProvider,
             IArmaProcessManager armaProcessManager,
             IArmaProcessFactory armaProcessFactory,
             ILogger<DedicatedServer> dedicatedServerLogger)
         {
-            _keysProvider = keysProvider;
+            _keysPreparer = keysPreparer;
             _serverConfigurationProvider = serverConfigurationProvider;
             _armaProcessManager = armaProcessManager;
             _armaProcessFactory = armaProcessFactory;
@@ -97,7 +97,7 @@ namespace ArmaForces.Arma.Server.Features.Servers
                 _port!.Value,
                 _modset,
                 modsetConfig,
-                _keysProvider,
+                _keysPreparer,
                 _armaProcessManager,
                 serverProcess,
                 headlessClients,

--- a/ArmaForces.Arma.Server/Features/Servers/ServerBuilderFactory.cs
+++ b/ArmaForces.Arma.Server/Features/Servers/ServerBuilderFactory.cs
@@ -1,26 +1,26 @@
-﻿using ArmaForces.Arma.Server.Features.Processes;
+﻿using ArmaForces.Arma.Server.Features.Keys;
+using ArmaForces.Arma.Server.Features.Processes;
 using ArmaForces.Arma.Server.Providers.Configuration;
-using ArmaForces.Arma.Server.Providers.Keys;
 using Microsoft.Extensions.Logging;
 
 namespace ArmaForces.Arma.Server.Features.Servers
 {
     public class ServerBuilderFactory : IServerBuilderFactory
     {
-        private readonly IKeysProvider _keysProvider;
+        private readonly IKeysPreparer _keysPreparer;
         private readonly IServerConfigurationProvider _serverConfigurationProvider;
         private readonly IArmaProcessManager _armaProcessManager;
         private readonly IArmaProcessFactory _armaProcessFactory;
         private readonly ILogger<DedicatedServer> _dedicatedServerLogger;
 
         public ServerBuilderFactory(
-            IKeysProvider keysProvider,
+            IKeysPreparer keysPreparer,
             IServerConfigurationProvider serverConfigurationProvider,
             IArmaProcessManager armaProcessManager,
             IArmaProcessFactory armaProcessFactory,
             ILogger<DedicatedServer> dedicatedServerLogger)
         {
-            _keysProvider = keysProvider;
+            _keysPreparer = keysPreparer;
             _serverConfigurationProvider = serverConfigurationProvider;
             _armaProcessManager = armaProcessManager;
             _armaProcessFactory = armaProcessFactory;
@@ -30,7 +30,7 @@ namespace ArmaForces.Arma.Server.Features.Servers
         public IServerBuilder CreateServerBuilder()
         {
             return new ServerBuilder(
-                _keysProvider,
+                _keysPreparer,
                 _serverConfigurationProvider,
                 _armaProcessManager,
                 _armaProcessFactory,

--- a/ArmaForces.ArmaServerManager.Tests/Features/Mods/ModsManagerIntegrationTests.cs
+++ b/ArmaForces.ArmaServerManager.Tests/Features/Mods/ModsManagerIntegrationTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Threading;
+using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Config;
+using ArmaForces.Arma.Server.Extensions;
+using ArmaForces.ArmaServerManager.Features.Mods;
+using ArmaForces.ArmaServerManager.Features.Steam.Content;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace ArmaForces.ArmaServerManager.Tests.Features.Mods
+{
+    public class ModsManagerIntegrationTests
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ModsManagerIntegrationTests()
+        {
+            var workingDirectory = Path.Join(Directory.GetCurrentDirectory(), "mods");
+            var fileSystemMock = PrepareWorkingDirectory(workingDirectory);
+            _serviceProvider = CreateServiceProvider(CreateSettingsMock(workingDirectory), fileSystemMock);
+        }
+
+        [Fact, Trait("Category", "Integration")]
+        public void UpdateAllMods_CancellationRequested_TaskCancelled()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(1));
+            
+            var modsManager = _serviceProvider.GetService<IModsManager>()!;
+
+            var task = modsManager.UpdateAllMods(cancellationTokenSource.Token);
+            Func<Task> action = async () => await task;
+
+            using (new AssertionScope())
+            {
+                action.Should().Throw<OperationCanceledException>();
+                task.IsCanceled.Should().BeTrue();
+            }
+        }
+
+        private static IFileSystem PrepareWorkingDirectory(string workingDirectory)
+        {
+            var fileSystemMock = new MockFileSystem();
+            fileSystemMock.Directory.CreateDirectory(workingDirectory);
+
+            return fileSystemMock;
+        }
+
+        private static IServiceProvider CreateServiceProvider(
+            ISettings settings,
+            IFileSystem fileSystem)
+        {
+            return new ServiceCollection()
+                .AddLogging()
+                .AddArmaServer()
+                .Replace(new ServiceDescriptor(typeof(ISettings), settings))
+                .AddSingleton(fileSystem)
+                .AddTransient<IModsCache, ModsCache>()
+                .AddTransient<IContentDownloader, ContentDownloader>()
+                .AddTransient(_ => Mock.Of<IContentVerifier>())
+                .AddTransient<IModsManager, ModsManager>()
+                .BuildServiceProvider();
+        }
+
+        private static ISettings CreateSettingsMock(string workingDirectory)
+        {
+            var settingsMock = new Mock<ISettings>();
+            
+            settingsMock.Setup(x => x.SteamUser).Returns("");
+            settingsMock.Setup(x => x.SteamPassword).Returns("");
+            settingsMock.Setup(x => x.ModsDirectory).Returns(workingDirectory);
+
+            return settingsMock.Object;
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager.sln.DotSettings
+++ b/ArmaForces.ArmaServerManager.sln.DotSettings
@@ -10,6 +10,8 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bikey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bikeys/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Downloader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hangfire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modset/@EntryIndexedValue">True</s:Boolean>

--- a/ArmaForces.ArmaServerManager/Features/Mods/IModsCache.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/IModsCache.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Features.Mods;
-using ArmaForces.Arma.Server.Features.Modsets;
-using ArmaForces.ArmaServerManager.Features.Modsets.DTOs;
 using CSharpFunctionalExtensions;
 
 namespace ArmaForces.ArmaServerManager.Features.Mods {

--- a/ArmaForces.ArmaServerManager/Features/Mods/ModsCache.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/ModsCache.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentVerifier.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ArmaForces.ArmaServerManager/Providers/Server/ServerProvider.cs
+++ b/ArmaForces.ArmaServerManager/Providers/Server/ServerProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text.Json.Serialization;
 using ArmaForces.Arma.Server.Config;
-using ArmaForces.Arma.Server.Features.Keys;
+using ArmaForces.Arma.Server.Extensions;
 using ArmaForces.Arma.Server.Features.Parameters;
 using ArmaForces.Arma.Server.Features.Processes;
 using ArmaForces.Arma.Server.Features.Servers;
@@ -36,7 +36,7 @@ namespace ArmaForces.ArmaServerManager
             Configuration = configuration;
         }
 
-        public IConfiguration Configuration { get; }
+        private IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -80,12 +80,14 @@ namespace ArmaForces.ArmaServerManager
 
             .AddSingleton<ISettings>(Settings.LoadSettings)
 
+            // Arma Server
+            .AddArmaServer()
+            
             // Mods
             .AddSingleton<ModsCache>()
-            .AddSingleton<IModsCache>(x => x.GetService<ModsCache>()!)
-            .AddSingleton<IWebModsetMapper>(x => x.GetService<ModsCache>()!)
+            .AddSingleton<IModsCache, ModsCache>()
+            .AddSingleton<IWebModsetMapper, ModsCache>()
             .AddSingleton<IModsManager, ModsManager>()
-            .AddSingleton<IModDirectoryFinder, ModDirectoryFinder>()
             .AddSingleton<IApiModsetClient, ApiModsetClient>()
             .AddSingleton<ISteamClient, SteamClient>()
             .AddSingleton<IManifestDownloader, ManifestDownloader>()
@@ -100,9 +102,6 @@ namespace ArmaForces.ArmaServerManager
             // Configuration
             .AddSingleton<ConfigFileCreator>()
             .AddSingleton<ConfigReplacer>()
-
-            // Keys
-            .AddSingleton<IKeysPreparer, KeysPreparer>()
 
             // Process
             .AddSingleton<IArmaProcessDiscoverer, ArmaProcessDiscoverer>()

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Text.Json.Serialization;
 using ArmaForces.Arma.Server.Config;
+using ArmaForces.Arma.Server.Features.Keys;
 using ArmaForces.Arma.Server.Features.Parameters;
 using ArmaForces.Arma.Server.Features.Processes;
 using ArmaForces.Arma.Server.Features.Servers;
 using ArmaForces.Arma.Server.Providers.Configuration;
-using ArmaForces.Arma.Server.Providers.Keys;
 using ArmaForces.ArmaServerManager.Features.Configuration;
 using ArmaForces.ArmaServerManager.Features.Hangfire;
 using ArmaForces.ArmaServerManager.Features.Hangfire.Helpers;
@@ -102,7 +102,7 @@ namespace ArmaForces.ArmaServerManager
             .AddSingleton<ConfigReplacer>()
 
             // Keys
-            .AddSingleton<IKeysProvider, KeysProvider>()
+            .AddSingleton<IKeysPreparer, KeysPreparer>()
 
             // Process
             .AddSingleton<IArmaProcessDiscoverer, ArmaProcessDiscoverer>()


### PR DESCRIPTION
This directory is located in `ExternalKeys` subdirectory of server config directory. Directory for mod should be created there (following one of the naming patterns for mod folders) and any bikeys should be copied there. This way users can again add bikeys after introducing #58 which deletes any user files in Steam Workshop mod directory.

Examples of external keys directory for `CBA_A3` mod:
- `C:\ArmaServer\ServerConfig\ExternalKeys\CBA_A3`
- `C:\ArmaServer\ServerConfig\ExternalKeys\@CBA_A3`
- `C:\ArmaServer\ServerConfig\ExternalKeys\450814997`

Fixes #59.