### PR TITLE
Fix CBA always updating

### DIFF
--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentFileVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentFileVerifier.cs
@@ -69,10 +69,16 @@ namespace ArmaForces.ArmaServerManager.Features.Steam.Content
 
             if (!_fileSystem.File.Exists(filePath)) return false;
 
+            var length = _fileSystem.FileInfo.FromFileName(filePath).Length;
+            if (length == 0 && file.TotalSize == 0)
+            {
+                return true;
+            }
+            
             using var fileStream = _fileSystem.FileStream.Create(filePath, FileMode.Open);
             using var bufferedStream = new BufferedStream(fileStream);
             using var sha1 = new SHA1Managed();
-
+            
             var localFileHash = sha1.ComputeHash(bufferedStream);
 
             return localFileHash.SequenceEqual(file.FileHash);

--- a/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentVerifier.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/Content/ContentVerifier.cs
@@ -43,20 +43,15 @@ namespace ArmaForces.ArmaServerManager.Features.Steam.Content
                 .Bind(x => GetManifest(x, cancellationToken))
                 // TODO: Move redundant files removing out of verification, returning redundant files should be separate from removing them.
                 .Tap(x => _contentFileVerifier.RemoveRedundantFiles(contentItem.Directory!, x))
-                .Bind(manifest => GetIncorrectFiles(contentItem, manifest));
+                .Bind(manifest => IsAnyFileOutdated(contentItem, manifest));
         }
 
-        private Result<List<ManifestFile>> GetIncorrectFiles(ContentItem contentItem, Manifest manifest)
-        {
-            return manifest.Files
+        private Result<List<ManifestFile>> IsAnyFileOutdated(ContentItem contentItem, Manifest manifest)
+            => manifest.Files
                 .SkipWhile(manifestFile => _contentFileVerifier.FileIsUpToDate(contentItem.Directory!, manifestFile))
                 .ToList();
-        }
 
         private async Task<Result<Manifest>> GetManifest(ContentItem contentItem, CancellationToken cancellationToken)
-        {
-            var manifest = await _manifestDownloader.GetManifest(contentItem, cancellationToken);
-            return Result.Success(manifest);
-        }
+            => await _manifestDownloader.GetManifest(contentItem, cancellationToken);
     }
 }


### PR DESCRIPTION
CBA was updating every time because `userconfig/cba_settings.sqf` has no content and expected hash is zero but the actual was not zero. Now all files (if there are any similar cases) will be considered as up to date if have no content and should have no content.