### PR TITLE
Ignore null values when serializing

### DIFF
--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -45,6 +45,7 @@ namespace ArmaForces.ArmaServerManager
                 {
                     opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
                     opt.JsonSerializerOptions.Converters.Add(new DateTimeOffsetConverter());
+                    opt.JsonSerializerOptions.IgnoreNullValues = true;
                 });
 
             // Add Hangfire services.


### PR DESCRIPTION
Now when requesting status when server is stopped, we don't get all properties with nulls.