### PR TITLE
Add indentation to API responses

### DIFF
--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -46,6 +46,7 @@ namespace ArmaForces.ArmaServerManager
                     opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
                     opt.JsonSerializerOptions.Converters.Add(new DateTimeOffsetConverter());
                     opt.JsonSerializerOptions.IgnoreNullValues = true;
+                    opt.JsonSerializerOptions.WriteIndented = true;
                 });
 
             // Add Hangfire services.


### PR DESCRIPTION
This is for our fellas who use browser to view server status, but their browser sucks and shows them raw, unformatted JSON. We may remove this once we create proper server status page.