### PR TITLE
Quick-check mods for updates on server startup using workshop item updated date

### DIFF
--- a/ArmaForces.ArmaServerManager.Tests/Features/Mods/ModsManagerUnitTests.cs
+++ b/ArmaForces.ArmaServerManager.Tests/Features/Mods/ModsManagerUnitTests.cs
@@ -8,6 +8,7 @@ using ArmaForces.ArmaServerManager.Extensions;
 using ArmaForces.ArmaServerManager.Features.Mods;
 using ArmaForces.ArmaServerManager.Features.Steam.Content;
 using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
+using ArmaForces.ArmaServerManager.Features.Steam.RemoteStorage;
 using AutoFixture;
 using CSharpFunctionalExtensions;
 using FluentAssertions;
@@ -24,6 +25,7 @@ namespace ArmaForces.ArmaServerManager.Tests.Features.Mods
         private readonly Mock<IModsCache> _modsCacheMock;
         private readonly Mock<IContentVerifier> _contentVerifierMock;
         private readonly Mock<IContentDownloader> _downloaderMock;
+        private readonly Mock<ISteamRemoteStorage> _steamRemoteStorageMock;
         private readonly ModsManager _modsManager;
 
         public ModsManagerUnitTests()
@@ -31,10 +33,12 @@ namespace ArmaForces.ArmaServerManager.Tests.Features.Mods
             _modsCacheMock = CreateModsCacheMock();
             _contentVerifierMock = CreateContentVerifierMock();
             _downloaderMock = CreateContentDownloaderMock();
+            _steamRemoteStorageMock = CreateSteamRemoteStorageMock();
             _modsManager = new ModsManager(
                 _downloaderMock.Object,
                 _contentVerifierMock.Object,
                 _modsCacheMock.Object,
+                _steamRemoteStorageMock.Object,
                 new NullLogger<ModsManager>());
         }
 
@@ -200,6 +204,17 @@ namespace ArmaForces.ArmaServerManager.Tests.Features.Mods
             mock
                 .Setup(x => x.DownloadOrUpdateMods(It.IsAny<IReadOnlyCollection<Mod>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new List<Result<Mod>>{Result.Failure<Mod>("Item could not be downloaded")}));
+
+            return mock;
+        }
+        
+        private Mock<ISteamRemoteStorage> CreateSteamRemoteStorageMock()
+        {
+            var mock = new Mock<ISteamRemoteStorage>();
+            
+            mock
+                .Setup(x => x.GetPublishedFileDetails(It.IsAny<IReadOnlyCollection<ulong>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new Result<PublishedFileDetails[]>()));
 
             return mock;
         }

--- a/ArmaForces.ArmaServerManager/Api/Jobs/DTOs/JobScheduleRequestDto.cs
+++ b/ArmaForces.ArmaServerManager/Api/Jobs/DTOs/JobScheduleRequestDto.cs
@@ -12,7 +12,7 @@ namespace ArmaForces.ArmaServerManager.Api.Jobs.DTOs
         /// Time when job should be processed.
         /// Exact start time will depend on other jobs processing and enqueued at this time.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime? ScheduleAt { get; set; }
     }
 }

--- a/ArmaForces.ArmaServerManager/Api/Status/DTOs/AppStatus.cs
+++ b/ArmaForces.ArmaServerManager/Api/Status/DTOs/AppStatus.cs
@@ -17,6 +17,11 @@
         UpdatingMods,
         
         /// <summary>
+        /// Mods are being verified.
+        /// </summary>
+        VerifyingMods,
+        
+        /// <summary>
         /// Server is starting.
         /// </summary>
         StartingServer,

--- a/ArmaForces.ArmaServerManager/Features/Mods/DependencyInjection/ModsServiceCollectionExtensions.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/DependencyInjection/ModsServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using ArmaForces.ArmaServerManager.Features.Modsets.DependencyInjection;
 using ArmaForces.ArmaServerManager.Features.Steam;
 using ArmaForces.ArmaServerManager.Features.Steam.Content;
+using ArmaForces.ArmaServerManager.Features.Steam.RemoteStorage;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ArmaForces.ArmaServerManager.Features.Mods.DependencyInjection
@@ -23,6 +24,7 @@ namespace ArmaForces.ArmaServerManager.Features.Mods.DependencyInjection
         private static IServiceCollection AddContent(this IServiceCollection services)
             => services
                 .AddScoped<ISteamClient, SteamClient>()
+                .AddScoped<ISteamRemoteStorage, SteamRemoteStorage>()
                 .AddScoped<IManifestDownloader, ManifestDownloader>()
                 .AddScoped<IContentDownloader, ContentDownloader>()
                 .AddScoped<IContentVerifier, ContentVerifier>()

--- a/ArmaForces.ArmaServerManager/Features/Mods/IModsManager.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/IModsManager.cs
@@ -5,11 +5,13 @@ using ArmaForces.Arma.Server.Features.Mods;
 using ArmaForces.Arma.Server.Features.Modsets;
 using CSharpFunctionalExtensions;
 
-namespace ArmaForces.ArmaServerManager.Features.Mods {
+namespace ArmaForces.ArmaServerManager.Features.Mods
+{
     /// <summary>
     /// Prepares modset by downloading missing mods and updating outdated mods.
     /// </summary>
-    public interface IModsManager {
+    public interface IModsManager
+    {
         /// <inheritdoc cref="IModsManager"/>
         /// <param name="modset">Modset to prepare.</param>
         /// <param name="cancellationToken"></param>
@@ -27,6 +29,7 @@ namespace ArmaForces.ArmaServerManager.Features.Mods {
         /// Checks if all mods from given list are up to date.
         /// </summary>
         /// <param name="modsList">List of mods to check.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns><see cref="Result{T}"/> with outdated mods.</returns>
         Task<Result<List<Mod>>> CheckModsUpdated(IReadOnlyCollection<Mod> modsList, CancellationToken cancellationToken);
 
@@ -42,5 +45,13 @@ namespace ArmaForces.ArmaServerManager.Features.Mods {
         /// </summary>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used for task cancellation.</param>
         Task UpdateAllMods(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Verifies all mods from given <paramref name="modsList"/>.
+        /// </summary>
+        /// <param name="modsList">List of mods to verify.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <returns><see cref="Result{T}"/> with mods which failed verification.</returns>
+        Task<Result<List<Mod>>> VerifyMods(IReadOnlyCollection<Mod> modsList, CancellationToken cancellationToken);
     }
 }

--- a/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
@@ -77,9 +77,12 @@ namespace ArmaForces.ArmaServerManager.Features.Mods
             {
                 return Result.Success(new List<Mod>());
             }
-
-            var workshopModIds = modsList
+            
+            var workshopMods = modsList
                 .Where(x => x.Source == ModSource.SteamWorkshop)
+                .ToList();
+
+            var workshopModIds = workshopMods
                 .Select(x => x.WorkshopId)
                 .Where(x => x.HasValue)
                 .Select(x => (ulong)x!.Value)
@@ -93,8 +96,11 @@ namespace ArmaForces.ArmaServerManager.Features.Mods
                 .Where(x => x.mod.LastUpdatedAt < x.details.LastUpdatedAt)
                 .Select(x => x.mod)
                 .ToList();
+
+            var modsNotInCache = workshopMods
+                .Where(x => _modsCache.Mods.NotContains(x));
             
-            return Result.Success(modsToUpdate);
+            return Result.Success(modsNotInCache.Concat(modsToUpdate).ToList());
         }
 
         /// <inheritdoc />

--- a/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
+++ b/ArmaForces.ArmaServerManager/Features/Mods/ModsManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,8 @@ using ArmaForces.Arma.Server.Features.Mods;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.ArmaServerManager.Extensions;
 using ArmaForces.ArmaServerManager.Features.Steam.Content;
+using ArmaForces.ArmaServerManager.Features.Steam.Content.DTOs;
+using ArmaForces.ArmaServerManager.Features.Steam.RemoteStorage;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
@@ -19,22 +22,26 @@ namespace ArmaForces.ArmaServerManager.Features.Mods
         private readonly IContentDownloader _contentDownloader;
         private readonly IContentVerifier _contentVerifier;
         private readonly IModsCache _modsCache;
+        private readonly ISteamRemoteStorage _steamRemoteStorage;
         private readonly ILogger<ModsManager> _logger;
 
         /// <inheritdoc cref="ModsManager" />
         /// <param name="contentDownloader">Client for mods download and updating.</param>
         /// <param name="contentVerifier">Client for verifying whether mods are up to date and correct.</param>
         /// <param name="modsCache">Installed mods cache.</param>
+        /// <param name="steamRemoteStorage">Steam remote storage for quick access to mods metadata on Workshop.</param>
         /// <param name="logger">Logger.</param>
         public ModsManager(
             IContentDownloader contentDownloader,
             IContentVerifier contentVerifier,
             IModsCache modsCache,
+            ISteamRemoteStorage steamRemoteStorage,
             ILogger<ModsManager> logger)
         {
             _contentDownloader = contentDownloader;
             _contentVerifier = contentVerifier;
             _modsCache = modsCache;
+            _steamRemoteStorage = steamRemoteStorage;
             _logger = logger;
         }
 
@@ -65,6 +72,33 @@ namespace ArmaForces.ArmaServerManager.Features.Mods
 
         /// <inheritdoc />
         public async Task<Result<List<Mod>>> CheckModsUpdated(IReadOnlyCollection<Mod> modsList, CancellationToken cancellationToken)
+        {
+            if (modsList.IsEmpty())
+            {
+                return Result.Success(new List<Mod>());
+            }
+
+            var workshopModIds = modsList
+                .Where(x => x.Source == ModSource.SteamWorkshop)
+                .Select(x => x.WorkshopId)
+                .Where(x => x.HasValue)
+                .Select(x => (ulong)x!.Value)
+                .ToList();
+
+            var publishedFileDetails = await _steamRemoteStorage.GetPublishedFileDetails(workshopModIds, cancellationToken);
+            
+            var modsToUpdate = _modsCache.Mods
+                .Join(publishedFileDetails.Value, mod => mod.WorkshopId, fileDetails => fileDetails.PublishedFileId,
+                    (mod, details) => new {mod, details})
+                .Where(x => x.mod.LastUpdatedAt < x.details.LastUpdatedAt)
+                .Select(x => x.mod)
+                .ToList();
+            
+            return Result.Success(modsToUpdate);
+        }
+
+        /// <inheritdoc />
+        public async Task<Result<List<Mod>>> VerifyMods(IReadOnlyCollection<Mod> modsList, CancellationToken cancellationToken)
         {
             if (modsList.IsEmpty())
             {

--- a/ArmaForces.ArmaServerManager/Features/Status/AppStatusStore.cs
+++ b/ArmaForces.ArmaServerManager/Features/Status/AppStatusStore.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using ArmaForces.ArmaServerManager.Api.Status.DTOs;
+using ArmaForces.ArmaServerManager.Features.Status.Models;
+
+namespace ArmaForces.ArmaServerManager.Features.Status;
+
+/// <summary>
+/// TODO: Consider doing this in a better way. For now it's fine.
+/// </summary>
+public class AppStatusStore : IAppStatusStore
+{
+    public AppStatusDetails? StatusDetails { get; private set; }
+    
+    public IDisposable SetAppStatus(AppStatus appStatus, string? longStatus = null)
+    {
+        var previousStatus = StatusDetails;
+        
+        StatusDetails = new AppStatusDetails
+        {
+            Status = appStatus,
+            LongStatus = longStatus
+        };
+
+        return new AppStatusDisposable(this, previousStatus);
+    }
+
+    public void ClearAppStatus()
+    {
+        StatusDetails = null;
+    }
+
+    private class AppStatusDisposable : IDisposable
+    {
+        private readonly AppStatusStore _appStatusStore;
+        private readonly AppStatusDetails? _previousStatus;
+
+        public AppStatusDisposable(AppStatusStore appStatusStore, AppStatusDetails? previousStatus)
+        {
+            _appStatusStore = appStatusStore;
+            _previousStatus = previousStatus;
+        }
+        
+        public void Dispose()
+        {
+            _appStatusStore.StatusDetails = _previousStatus;
+        }
+    }
+}
+
+public interface IAppStatusStore
+{
+    AppStatusDetails? StatusDetails { get; }
+
+    IDisposable SetAppStatus(AppStatus appStatus, string? longStatus = null);
+    
+    void ClearAppStatus();
+}

--- a/ArmaForces.ArmaServerManager/Features/Status/StatusProvider.cs
+++ b/ArmaForces.ArmaServerManager/Features/Status/StatusProvider.cs
@@ -104,11 +104,6 @@ namespace ArmaForces.ArmaServerManager.Features.Status
                     Status = AppStatus.VerifyingMods,
                     LongStatus = $"Verifying mods from {currentJobDetails.GetParameterValue("modsetName")}"
                 },
-                nameof(ModsVerificationService.VerifyMods) => new AppStatusDetails
-                {
-                    Status = AppStatus.VerifyingMods,
-                    LongStatus = $"Verifying mods with ids {currentJobDetails.GetParameterValue("modIds")}"
-                },
                 nameof(ServerStartupService.StartServerForMission) => new AppStatusDetails
                 {
                     Status = AppStatus.StartingServer,

--- a/ArmaForces.ArmaServerManager/Features/Steam/RemoteStorage/ISteamRemoteStorage.cs
+++ b/ArmaForces.ArmaServerManager/Features/Steam/RemoteStorage/ISteamRemoteStorage.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+
+namespace ArmaForces.ArmaServerManager.Features.Steam.RemoteStorage;
+
+/// <summary>
+/// https://partner.steamgames.com/doc/webapi/ISteamRemoteStorage
+/// </summary>
+public interface ISteamRemoteStorage
+{
+    /// <summary>
+    /// Retrieves details of published file (workshop item).
+    /// </summary>
+    /// <param name="publishedFileIds">IDs of workshop items to retrieve details for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Result<PublishedFileDetails[]>> GetPublishedFileDetails(IEnumerable<ulong> publishedFileIds, CancellationToken cancellationToken);
+}
+
+internal class SteamRemoteStorage : ISteamRemoteStorage
+{
+    private const string GetPublishedFileDetailsUrl =
+        "https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/";
+    
+    private readonly HttpClient _httpClient;
+
+    public SteamRemoteStorage(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+    
+    public async Task<Result<PublishedFileDetails[]>> GetPublishedFileDetails(IEnumerable<ulong> publishedFileIds, CancellationToken cancellationToken)
+    {
+        var idsQueryList = publishedFileIds.ToList();
+
+        var requestedItems = new Dictionary<string, string>
+        {
+            {"itemcount", idsQueryList.Count.ToString()}
+        };
+        
+        for (var i = 0; i < idsQueryList.Count; i++)
+        {
+            requestedItems.Add($"publishedfileids[{i}]", idsQueryList[i].ToString());
+        }
+
+        var requestContent = new FormUrlEncodedContent(requestedItems);
+
+        var response = await _httpClient.PostAsync(GetPublishedFileDetailsUrl, requestContent, cancellationToken);
+
+        var responseData = await response.Content.ReadAsStringAsync(cancellationToken);
+        
+        if (!response.IsSuccessStatusCode) return Result.Failure<PublishedFileDetails[]>(responseData);
+
+        var publishedFileDetails = JsonSerializer.Deserialize<JsonObject>(responseData)?.Single().Value?.AsObject()
+            ["publishedfiledetails"].Deserialize<PublishedFileDetailsRaw[]>();
+
+        if (publishedFileDetails is null) return Result.Failure<PublishedFileDetails[]>($"Failed parsing published file details. Response: {responseData}");
+
+        return Result.Success(publishedFileDetails
+            .Select(x => new PublishedFileDetails
+            {
+                PublishedFileId = long.Parse(x.PublishedFileId),
+                Title = x.Title,
+                LastUpdatedAt = DateTimeOffset.FromUnixTimeSeconds(x.TimeUpdated)
+            })
+            .ToArray());
+    }
+
+    private record PublishedFileDetailsRaw
+    {
+        [JsonPropertyName("publishedfileid")]
+        public string PublishedFileId { get; init; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; init; } = string.Empty;
+    
+        [JsonPropertyName("time_updated")]
+        public long TimeUpdated { get; init; }
+    }
+}
+
+public record PublishedFileDetails
+{
+    public long PublishedFileId { get; init; }
+
+    public string Title { get; init; } = string.Empty;
+    
+    public DateTimeOffset LastUpdatedAt { get; init; }
+}

--- a/ArmaForces.ArmaServerManager/Properties/launchSettings.json
+++ b/ArmaForces.ArmaServerManager/Properties/launchSettings.json
@@ -17,6 +17,8 @@
     },
     "Arma.Server.Manager": {
       "commandName": "Project",
+      "executablePath": "D:\\Program Files\\ArmaServerManager\\ArmaForces.ArmaServerManager.exe",
+      "workingDirectory": "D:\\Program Files\\ArmaServerManager",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "launchUrl": "api-docs/",

--- a/ArmaForces.ArmaServerManager/Services/IModsUpdateService.cs
+++ b/ArmaForces.ArmaServerManager/Services/IModsUpdateService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Features.Mods;
@@ -7,6 +7,9 @@ using CSharpFunctionalExtensions;
 
 namespace ArmaForces.ArmaServerManager.Services
 {
+    /// <summary>
+    /// Performs updates of installed mods.
+    /// </summary>
     public interface IModsUpdateService
     {
         Task<Result> UpdateModset(string modsetName, CancellationToken cancellationToken);

--- a/ArmaForces.ArmaServerManager/Services/IModsVerificationService.cs
+++ b/ArmaForces.ArmaServerManager/Services/IModsVerificationService.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Features.Modsets;
+using CSharpFunctionalExtensions;
+
+namespace ArmaForces.ArmaServerManager.Services;
+
+/// <summary>
+///  Performs detailed verifications of installed mods.
+/// </summary>
+public interface IModsVerificationService
+{
+    /// <summary>
+    /// Runs detailed verification of given <paramref name="modset"/>.
+    /// </summary>
+    /// <param name="modset">Modset with mods to verify.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Successful result if all mods were verified correctly.</returns>
+    Task<Result> VerifyModset(Modset modset, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves modset with given <paramref name="modsetName"/> and runs a detailed verification.
+    /// </summary>
+    /// <param name="modsetName">Name of the modset to retrieve and verify.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Successful result if all mods were verified correctly.</returns>
+    Task<Result> VerifyModset(string modsetName, CancellationToken cancellationToken);
+}

--- a/ArmaForces.ArmaServerManager/Services/IModsVerificationService.cs
+++ b/ArmaForces.ArmaServerManager/Services/IModsVerificationService.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Features.Mods;
 using ArmaForces.Arma.Server.Features.Modsets;
 using CSharpFunctionalExtensions;
 
@@ -26,4 +27,12 @@ public interface IModsVerificationService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Successful result if all mods were verified correctly.</returns>
     Task<Result> VerifyModset(string modsetName, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Runs detailed verification of <paramref name="mods"/>.
+    /// </summary>
+    /// <param name="mods">List of mods to verify.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Successful result if all mods were verified correctly.</returns>
+    Task<Result> VerifyMods(IEnumerable<Mod> mods, CancellationToken cancellationToken);
 }

--- a/ArmaForces.ArmaServerManager/Services/MissionPreparationService.cs
+++ b/ArmaForces.ArmaServerManager/Services/MissionPreparationService.cs
@@ -20,19 +20,22 @@ namespace ArmaForces.ArmaServerManager.Services
         private readonly IWebModsetMapper _webModsetMapper;
         private readonly IServerStartupService _serverStartupService;
         private readonly IModsUpdateService _modsUpdateService;
+        private readonly IModsVerificationService _modsVerificationService;
 
         public MissionPreparationService(
             IApiMissionsClient apiMissionsClient,
             IApiModsetClient apiModsetClient,
             IWebModsetMapper webModsetMapper,
             IServerStartupService serverStartupService,
-            IModsUpdateService modsUpdateService)
+            IModsUpdateService modsUpdateService,
+            IModsVerificationService modsVerificationService)
         {
             _apiMissionsClient = apiMissionsClient;
             _apiModsetClient = apiModsetClient;
             _webModsetMapper = webModsetMapper;
             _serverStartupService = serverStartupService;
             _modsUpdateService = modsUpdateService;
+            _modsVerificationService = modsVerificationService;
         }
 
         /// <inheritdoc />
@@ -40,7 +43,7 @@ namespace ArmaForces.ArmaServerManager.Services
         {
             return await _apiMissionsClient.GetUpcomingMissionsModsetsNames()
                 .Bind(GetModsListFromModsets)
-                .Tap(x => _modsUpdateService.UpdateMods(x, cancellationToken))
+                .Tap(x => _modsVerificationService.VerifyMods(x, cancellationToken))
                 .Bind(_ => Result.Success());
         }
 

--- a/ArmaForces.ArmaServerManager/Services/ModsVerificationService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ModsVerificationService.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ArmaForces.Arma.Server.Features.Mods;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.ArmaServerManager.Features.Mods;
 using ArmaForces.ArmaServerManager.Features.Modsets;
@@ -32,6 +33,12 @@ namespace ArmaForces.ArmaServerManager.Services
         public async Task<Result> VerifyModset(Modset modset, CancellationToken cancellationToken)
         {
             return await _modsManager.VerifyMods(modset.Mods.ToList(), cancellationToken);
+        }
+        
+        /// <inheritdoc />
+        public async Task<Result> VerifyMods(IEnumerable<Mod> mods, CancellationToken cancellationToken)
+        {
+            return await _modsManager.VerifyMods(mods.ToList(), cancellationToken);
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Services/ModsVerificationService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ModsVerificationService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.ArmaServerManager.Features.Mods;
@@ -7,7 +9,10 @@ using CSharpFunctionalExtensions;
 
 namespace ArmaForces.ArmaServerManager.Services
 {
-    public class ModsVerificationService
+    /// <summary>
+    /// Service allowing mods verification.
+    /// </summary>
+    public class ModsVerificationService : IModsVerificationService
     {
         private readonly IModsManager _modsManager;
         private readonly IModsetProvider _modsetProvider;
@@ -18,13 +23,15 @@ namespace ArmaForces.ArmaServerManager.Services
             _modsetProvider = modsetProvider;
         }
 
+        /// <inheritdoc />
         public async Task<Result> VerifyModset(string modsetName, CancellationToken cancellationToken)
             => await _modsetProvider.GetModsetByName(modsetName)
                 .Bind(x => VerifyModset(x, cancellationToken));
 
-        private async Task<Result> VerifyModset(Modset modset, CancellationToken cancellationToken)
+        /// <inheritdoc />
+        public async Task<Result> VerifyModset(Modset modset, CancellationToken cancellationToken)
         {
-            return await _modsManager.PrepareModset(modset, cancellationToken);
+            return await _modsManager.VerifyMods(modset.Mods.ToList(), cancellationToken);
         }
     }
 }

--- a/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
+++ b/ArmaForces.ArmaServerManager/Services/ServerStartupService.cs
@@ -1,13 +1,16 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ArmaForces.Arma.Server.Features.Modsets;
 using ArmaForces.ArmaServerManager.Api.Servers.DTOs;
+using ArmaForces.ArmaServerManager.Api.Status.DTOs;
 using ArmaForces.ArmaServerManager.Features.Missions;
 using ArmaForces.ArmaServerManager.Features.Missions.DTOs;
 using ArmaForces.ArmaServerManager.Features.Modsets;
 using ArmaForces.ArmaServerManager.Features.Servers;
+using ArmaForces.ArmaServerManager.Features.Status;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +23,7 @@ namespace ArmaForces.ArmaServerManager.Services
     {
         private const int Port = 2302;
 
+        private readonly IAppStatusStore _appStatusStore;
         private readonly IApiMissionsClient _apiMissionsClient;
         private readonly IModsetProvider _modsetProvider;
         private readonly IServerCommandLogic _serverCommandLogic;
@@ -27,12 +31,14 @@ namespace ArmaForces.ArmaServerManager.Services
         private readonly ILogger<ServerStartupService> _logger;
 
         public ServerStartupService(
+            IAppStatusStore appStatusStore,
             IApiMissionsClient apiMissionsClient,
             IModsetProvider modsetProvider,
             IServerCommandLogic serverCommandLogic,
             IModsUpdateService modsUpdateService,
             ILogger<ServerStartupService> logger)
         {
+            _appStatusStore = appStatusStore;
             _apiMissionsClient = apiMissionsClient;
             _modsetProvider = modsetProvider;
             _serverCommandLogic = serverCommandLogic;
@@ -64,11 +70,15 @@ namespace ArmaForces.ArmaServerManager.Services
 
         public async Task<Result> StartServer(Modset modset, int headlessClients, CancellationToken cancellationToken)
         {
+            IDisposable? appStatusChanges = null;
+            
             return await ShutdownServer(
                 Port,
                 false,
                 cancellationToken)
-                //.Bind(() => _modsUpdateService.UpdateModset(modset, cancellationToken))
+                .Tap(() => appStatusChanges = _appStatusStore.SetAppStatus(AppStatus.UpdatingMods, $"Updating mods for server with '{modset.Name}' modset"))
+                .Bind(() => _modsUpdateService.UpdateModset(modset, cancellationToken))
+                .Tap(() => appStatusChanges?.Dispose())
                 .Bind(() => _serverCommandLogic.StartServer(Port, headlessClients, modset))
                 .Tap(() => _logger.LogInformation("Successfully started server on {Port} port with {ModsetName} modset", Port, modset.Name));
         }

--- a/ArmaForces.ArmaServerManager/Startup.cs
+++ b/ArmaForces.ArmaServerManager/Startup.cs
@@ -101,6 +101,7 @@ namespace ArmaForces.ArmaServerManager
             .AddScoped<MaintenanceService>()
             .AddScoped<IMissionPreparationService, MissionPreparationService>()
             .AddScoped<IModsUpdateService, ModsUpdateService>()
+            .AddScoped<IModsVerificationService, ModsVerificationService>()
             .AddScoped<IServerStartupService, ServerStartupService>()
 
             // Arma Server
@@ -124,6 +125,7 @@ namespace ArmaForces.ArmaServerManager
             .AddSingleton<IServerQueryLogic, ServerQueryLogic>()
             
             // Status
+            .AddSingleton<IAppStatusStore, AppStatusStore>()
             .AddSingleton<IStatusProvider, StatusProvider>()
 
             // Hangfire


### PR DESCRIPTION
- Adds quick check for update during server startup
- Adds ability to manually trigger modset verification (old style detailed update) `api/mods/{modsetName}/verify`
- Removes detailed verification from update mods `api/mods/{modsetName}/update`
- Ability to display more contextual app status, e.g., when app is updating mods before starting up the server, so users will know that's happening instead of just "starting server".

Fixes #86.